### PR TITLE
registerPriceModifier + Input Convention

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,7 @@
 - [~] Companion read API on `g_currentMission.MarketDynamics`: getActiveEvents() is live; getEligibleEvents() is still pending (ProStaff L20 early-warning). Price/trend reads to follow.
 - [x] StateLedger migration: `MarketDynamics_State` bridge live (b740771); own XML kept as the safety copy. Shipped v1.2.0.9.
 - [x] NetworkSync migration: fully bridged, contract action channel (3bd0255) + state-sync module (ad70e30), replacing the custom event classes. Shipped v1.2.0.9.
+- [x] 2026-07-26 bug sweep: MDM auth gate, MDM persistence, MDM bcManaged bugs fixed and merged to main.
 
 ## Mid-term (this season)
 - [x] MasterHUD: MDMHUD + settings panel bridged; own draw stands down when active. Shipped v1.2.0.9.

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@
 - [x] MP contract-admin exploit (f15715b): contract admin actions now require an actual admin, not just ownership. Closes a multiplayer path where a non-admin farm owner could trigger admin-only contract actions.
 - [x] Daily price shift ran 60x too often (6c54f8c): the daily market price shift fired every 24 in-game minutes instead of once per in-game day. Now fires once per in-game day. This is the ledger's MDM `DAILY_INTERVAL` 60x gremlin (MarketEngine.lua), closed.
 - [x] Money-authority (F15-class futures settlement): VERIFIED server-gated in live source. Both settlement paths bail on pure clients before `addMoney` (FuturesMarket.lua:217 `_fulfillContract`, :287 `_defaultContract`, via `if g_currentMission.isClient and not g_currentMission.isServer then return`), plus a double-pay guard (:210). The 2026-07-09 money-authority sweep flagged this as ungated, but it grepped `getIsServer` and missed the valid `.isServer`/`.isClient` field guard. Not a bug.
+- [x] 2026-07-26 bug sweep: MDM auth gate, MDM persistence, MDM bcManaged bugs fixed and merged to main. All closed.
 
 ## Features / enhancements
 - [ ] `getEligibleEvents()` to unblock ProStaff L20 early-warning (off-cooldown, not-active events).

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -60,15 +60,9 @@
     </extraSourceFiles>
 
     <actions>
-        <action name="MDM_MARKET_SCREEN" category="ONFOOT VEHICLE" axisType="HALF" ignoreComboMask="false">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_F10" />
-        </action>
-        <action name="MDM_CREATE_CONTRACT" category="ONFOOT VEHICLE" axisType="HALF" ignoreComboMask="false">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_N" />
-        </action>
-        <action name="MDM_OPEN_SETTINGS" category="ONFOOT VEHICLE" axisType="HALF" ignoreComboMask="false">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_F5" />
-        </action>
+        <action name="MDM_MARKET_SCREEN" category="ONFOOT VEHICLE" axisType="HALF" ignoreComboMask="false" />
+        <action name="MDM_CREATE_CONTRACT" category="ONFOOT VEHICLE" axisType="HALF" ignoreComboMask="false" />
+        <action name="MDM_OPEN_SETTINGS" category="ONFOOT VEHICLE" axisType="HALF" ignoreComboMask="false" />
     </actions>
 
     <!-- l10n definitions for input bindings (required for help display) -->

--- a/src/MarketDynamics.lua
+++ b/src/MarketDynamics.lua
@@ -51,6 +51,11 @@ function MarketDynamics.new(modDir, modName)
     self.futuresMarket = FuturesMarket.new()
     self.serializer    = MarketSerializer
 
+    -- Consumer price modifier registry: external mods register multiplier callbacks
+    -- via registerPriceModifier(name, fn). Each registered fn receives a context table
+    -- and returns a multiplier that is applied to the final price.
+    self.priceModifiers = {}
+
     -- Expose BCIntegration so external mods (e.g. BetterContracts) can reach it via
     -- g_MarketDynamics.bcIntegration without depending on the global table name.
     self.bcIntegration = BCIntegration
@@ -238,6 +243,26 @@ function MarketDynamics:delete()
         g_MDMHud:delete()
     end
     MDMLog.info("MarketDynamics: deleted")
+end
+
+-- ---------------------------------------------------------------------------
+-- Price Modifier Registry
+-- ---------------------------------------------------------------------------
+
+---Register a consumer price modifier. The callback receives a context table and must
+---return a positive number (multiplier) or nil to opt out of this fill type.
+---@param name string  Unique identifier (e.g. mod name or system name)
+---@param fn   function(ctx) -> number|nil
+function MarketDynamics:registerPriceModifier(name, fn)
+    self.priceModifiers[name] = fn
+    MDMLog.info("MarketDynamics: registered price modifier '" .. tostring(name) .. "'")
+end
+
+---Remove a previously registered consumer price modifier by name.
+---@param name string
+function MarketDynamics:unregisterPriceModifier(name)
+    self.priceModifiers[name] = nil
+    MDMLog.info("MarketDynamics: unregistered price modifier '" .. tostring(name) .. "'")
 end
 
 -- ---------------------------------------------------------------------------

--- a/src/MarketEngine.lua
+++ b/src/MarketEngine.lua
@@ -258,5 +258,25 @@ function MarketEngine:_recalculate(fillTypeIndex)
     for _, mod in ipairs(entry.modifiers) do
         factor = factor * mod.factor
     end
-    entry.current = entry.base * factor
+    local currentPrice = entry.base * factor
+
+    -- Consumer composition: product of all registered modifier multipliers
+    if g_MarketDynamics and g_MarketDynamics.priceModifiers then
+        local consumerMult = 1.0
+        for name, fn in pairs(g_MarketDynamics.priceModifiers) do
+            local ok, mult = pcall(fn, {
+                fillTypeIndex = fillTypeIndex,
+                basePrice = entry.base,
+                marketPrice = currentPrice,
+            })
+            if ok and type(mult) == "number" and mult > 0 then
+                consumerMult = consumerMult * mult
+            end
+        end
+        -- Clamp B: consumer composition band (provisional 0.5-3.0)
+        consumerMult = math.max(0.5, math.min(3.0, consumerMult))
+        currentPrice = currentPrice * consumerMult
+    end
+
+    entry.current = currentPrice
 end


### PR DESCRIPTION
## Changes

### Consumer Price Composition Bridge
- Added registerPriceModifier(name, fn) / unregisterPriceModifier(name) registry
- Consumer modifiers compose as product() inside composition clamp B (0.5-3.0 provisional)
- pcall-guarded per modifier, neutral-when-absent (1.0)
- Consumer context: fillTypeIndex, basePrice, marketPrice
- Organic premium is the first registered consumer

### Input Convention (B2)
- Cleared default bindings: MDM_MARKET_SCREEN (F10), MDM_CREATE_CONTRACT (N), MDM_OPEN_SETTINGS (F5)