### PR TITLE
fix: load-phase guard to stop expire/restore during MP join

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - Baseline date: 2026-06-29 (updated 2026-07-25)
 
 ## Near-term (next release cycle)
+- [x] Witcombe join load-phase guard (ad958a0): load-phase flag prevents expire/restore/price-shift logic during MP join. Pushed 2026-07-28.
 - [~] Companion read API on `g_currentMission.MarketDynamics`: getActiveEvents() is live; getEligibleEvents() is still pending (ProStaff L20 early-warning). Price/trend reads to follow.
 - [x] StateLedger migration: `MarketDynamics_State` bridge live (b740771); own XML kept as the safety copy. Shipped v1.2.0.9.
 - [x] NetworkSync migration: fully bridged, contract action channel (3bd0255) + state-sync module (ad70e30), replacing the custom event classes. Shipped v1.2.0.9.

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,7 @@
 - [ ] Handle capitalization is `g_currentMission.MarketDynamics` (capital M); ensure CropDisease and ProStaff briefs use it, and poll `getActiveEvents()` matching by id string.
 
 ## Bugs
+- [x] Witcombe join load-gates: expire/restore/price-shift fired during MP join before saved state was settled. Added `_loadPhase` flag in MarketDynamics.lua — zeroes timers and skips all subsystems until onStartMission completes. Commit ad958a0, pushed 2026-07-28.
 - [x] MP contract-admin exploit (f15715b): contract admin actions now require an actual admin, not just ownership. Closes a multiplayer path where a non-admin farm owner could trigger admin-only contract actions.
 - [x] Daily price shift ran 60x too often (6c54f8c): the daily market price shift fired every 24 in-game minutes instead of once per in-game day. Now fires once per in-game day. This is the ledger's MDM `DAILY_INTERVAL` 60x gremlin (MarketEngine.lua), closed.
 - [x] Money-authority (F15-class futures settlement): VERIFIED server-gated in live source. Both settlement paths bail on pure clients before `addMoney` (FuturesMarket.lua:217 `_fulfillContract`, :287 `_defaultContract`, via `if g_currentMission.isClient and not g_currentMission.isServer then return`), plus a double-pay guard (:210). The 2026-07-09 money-authority sweep flagged this as ungated, but it grepped `getIsServer` and missed the valid `.isServer`/`.isClient` field guard. Not a bug.

--- a/src/MarketDynamics.lua
+++ b/src/MarketDynamics.lua
@@ -28,6 +28,7 @@ function MarketDynamics.new(modDir, modName)
     self.modDir   = modDir
     self.modName  = modName
     self.isActive = false
+    self._loadPhase = true
 
     -- Player-configurable settings (persisted by MarketSerializer, edited via SettingsUI)
     -- Add new settings here and wire them in MarketSerializer + SettingsUI.
@@ -154,6 +155,8 @@ function MarketDynamics:onStartMission(mission)
     -- Register with SettingsHub (if installed) so FarmTablet's System Settings
     -- app can list Market Dynamics' settings. No-ops safely if SettingsHub is absent.
     MDMSettingsHubBridge.register(self)
+
+    self._loadPhase = false
 end
 
 -- Per-frame tick. dt = in-game milliseconds from FSBaseMission.update.
@@ -169,6 +172,18 @@ function MarketDynamics:update(dt)
     -- Safety: If we just loaded, wait until 'now' has caught up to 'lastSavedGameTime'
     -- This prevents immediate contract defaults if the day/time hasn't finished syncing.
     if self.lastSavedGameTime and now < self.lastSavedGameTime then
+        return
+    end
+
+    -- Load-phase guard: skip all expire/restore/price-shift logic during the
+    -- initial join/load window. The onStartMission() clears this flag once all
+    -- saved state is restored. Without this guard, events can expire and contracts
+    -- can default prematurely on MP join because the simulation catches up to saved
+    -- timestamps before the client has received its full initial state.
+    if self._loadPhase then
+        -- Zero timers so they don't accumulate during loading and fire on resume
+        self.marketEngine.intradayTimer = 0
+        self.marketEngine.dailyTimer = 0
         return
     end
 


### PR DESCRIPTION
Witcombe join-hang lane. Stops MarketDynamics doing price work while a client is still joining.

## What lands

- `_loadPhase` flag blocks all expire/restore/price-shift logic during MP join.
- Timers zero on resume so nothing fires a backlog the moment the gate lifts.
- ROADMAP and TODO updated.

## Why

Client joins to the GPortal dedicated (Witcombe Park Farm) were sticking around 89 percent. MarketDynamics expire/restore churn during load was ranked in the second evidence tier behind the SoilFertilizer value-map join storm. This closes the MarketDynamics half.

The SoilFertilizer join-stream half is separate (PR #756 in that repo plus the event-id defer).

Server-side only. No contract change to `registerPriceModifier`, so no Authority #3 re-trigger.