### PR TITLE
feat: wire the release gate mechanism; empty lock set

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -15,6 +15,7 @@
 
     <extraSourceFiles>
         <sourceFile filename="src/Logger.lua" />
+        <sourceFile filename="src/ReleaseGate.lua" />
         <sourceFile filename="src/MarketEngine.lua" />
         <sourceFile filename="src/WorldEventSystem.lua" />
         <sourceFile filename="src/FuturesMarket.lua" />

--- a/src/AdminCommands.lua
+++ b/src/AdminCommands.lua
@@ -52,6 +52,15 @@ local function cmdStatus(self)
     print("==================")
 end
 
+local function cmdRelease(self)
+    if not ReleaseGate then
+        print("[MDM] Release gate not loaded")
+        return
+    end
+    local optIn = g_MarketDynamics and g_MarketDynamics:allowsExperimentalSystems()
+    print(ReleaseGate.status(optIn))
+end
+
 local function cmdEvent(self, eventId)
     if not eventId or eventId == "" then
         print("[MDM] Usage: mdmEvent <eventId>")
@@ -219,6 +228,7 @@ function MDMAdminCommands_register()
     g_MarketDynamics.cmdMdmPrice     = cmdPrice
     g_MarketDynamics.cmdMdmEvents    = cmdEvents
     g_MarketDynamics.cmdMdmReloadGui = cmdReloadGui
+    g_MarketDynamics.cmdMdmRelease   = cmdRelease
 
     addConsoleCommand("mdmStatus",    "MDM: system health and active events",          "cmdMdmStatus",    g_MarketDynamics)
     addConsoleCommand("mdmEvent",     "MDM: force-fire event (arg: eventId)",          "cmdMdmEvent",     g_MarketDynamics)
@@ -226,8 +236,9 @@ function MDMAdminCommands_register()
     addConsoleCommand("mdmPrice",     "MDM: show price for a crop (arg: cropName)",    "cmdMdmPrice",     g_MarketDynamics)
     addConsoleCommand("mdmEvents",    "MDM: list all registered events and status",    "cmdMdmEvents",    g_MarketDynamics)
     addConsoleCommand("mdmReloadGui", "MDM: hot-reload modal dialog XML without restart", "cmdMdmReloadGui", g_MarketDynamics)
+    addConsoleCommand("mdmRelease",   "MDM: release gate status (STABLE vs LOCKED)",   "cmdMdmRelease",   g_MarketDynamics)
 
-    MDMLog.info("AdminCommands: registered 6 console commands")
+    MDMLog.info("AdminCommands: registered 7 console commands")
 end
 
 function MDMAdminCommands_remove()
@@ -237,4 +248,5 @@ function MDMAdminCommands_remove()
     removeConsoleCommand("mdmPrice")
     removeConsoleCommand("mdmEvents")
     removeConsoleCommand("mdmReloadGui")
+    removeConsoleCommand("mdmRelease")
 end

--- a/src/MDMSettingsHubBridge.lua
+++ b/src/MDMSettingsHubBridge.lua
@@ -45,6 +45,7 @@ function MDMSettingsHubBridge.register(mdm)
         { id = "eventNotificationBanner", type = "bool",  default = s.eventNotificationBanner, adminOnly = false, label = "Notifications As Banner" },
         { id = "showContractHUD",         type = "bool",  default = s.showContractHUD,         adminOnly = false, label = "Contract HUD" },
         { id = "debugMode",               type = "bool",  default = s.debugMode,               adminOnly = false, label = "Debug Mode" },
+        { id = "experimentalSystems",     type = "bool",  default = s.experimentalSystems,     adminOnly = true,  label = "Experimental Systems" },
     }
 
     local ok, err = pcall(function()

--- a/src/MarketDynamics.lua
+++ b/src/MarketDynamics.lua
@@ -44,6 +44,8 @@ function MarketDynamics.new(modDir, modName)
         useRealDays          = false, -- When true, contract delivery windows track real-world time
         disabledEvents       = {},    -- { [eventId] = true } — events that won't roll
         eventCustomFillTypes = {},    -- { [eventId] = { fillTypeName, ... } }
+        -- Release-gate opt-in (default false), orthogonal to difficulty. See ReleaseGate.lua.
+        experimentalSystems  = false,
     }
 
     -- Subsystems
@@ -66,6 +68,13 @@ function MarketDynamics.new(modDir, modName)
     local modInfo = g_modManager:getModByName(modName)
     MDMLog.info("MarketDynamics created — v" .. (modInfo and modInfo.version or "?"))
     return self
+end
+
+--- Release-gate opt-in. True when the player has explicitly enabled experimental
+--- (LOCKED) systems. Orthogonal to difficulty: the two locks stack, see ReleaseGate.lua.
+---@return boolean
+function MarketDynamics:allowsExperimentalSystems()
+    return self.settings.experimentalSystems == true
 end
 
 -- Called after mission is fully loaded. Safe to access all game APIs from here.

--- a/src/MarketSerializer.lua
+++ b/src/MarketSerializer.lua
@@ -133,6 +133,7 @@ function MarketSerializer:save(coordinator)
         xmlFile:setBool ("marketDynamics.settings#eventNotificationBanner", s.eventNotificationBanner == true)
         xmlFile:setBool ("marketDynamics.settings#showContractHUD",       s.showContractHUD       ~= false)
         xmlFile:setBool ("marketDynamics.settings#useRealDays",           s.useRealDays           == true)
+        xmlFile:setBool ("marketDynamics.settings#experimentalSystems",   s.experimentalSystems   == true)
 
         -- Disabled events: { [eventId] = true }
         local de = s.disabledEvents or {}
@@ -378,6 +379,9 @@ function MarketSerializer:load(coordinator)
 
         local useRealDays = xmlFile:getBool("marketDynamics.settings#useRealDays")
         if useRealDays ~= nil then s.useRealDays = useRealDays end
+
+        local experimentalSystems = xmlFile:getBool("marketDynamics.settings#experimentalSystems")
+        if experimentalSystems ~= nil then s.experimentalSystems = experimentalSystems end
 
         -- Disabled events
         s.disabledEvents = {}

--- a/src/ReleaseGate.lua
+++ b/src/ReleaseGate.lua
@@ -1,0 +1,106 @@
+-- =========================================================
+-- FS25 Market Dynamics - Release Gate
+-- =========================================================
+-- The release gate: which systems are released (STABLE) vs experimental (LOCKED).
+--
+-- Orthogonal to difficulty. The gate is its own explicit opt-in (experimental
+-- systems, on at your own risk), independent of difficulty, and the two locks
+-- STACK.
+--
+-- Arissani's certification (2026-08-03, ledger): Market Dynamics carries an
+-- EMPTY lock set today. The price-modifier contract is present but inert (its one
+-- adopter returns nil or 1.0 and changes no price), and OM-213 the organic premium
+-- is unbuilt and owed from the design side. Nothing is gated; the mechanism is
+-- wired so a row can be added the moment a system needs locking. Releasing a
+-- system for a stable release is a deliberate act, never a default.
+-- =========================================================
+
+ReleaseGate = {}
+
+-- The certified experimental (LOCKED) set. Each entry: [systemId] = { name, status }.
+-- `status` is a SHORT player-facing note on what is not working or implemented yet.
+-- A system that is NOT in this table is released (the proven baseline).
+ReleaseGate.EXPERIMENTAL = {}
+
+-- Console command -> systemId, so command refusals route through the same registry.
+ReleaseGate.COMMAND_TO_SYSTEM = {}
+
+--- A system is released when it is NOT experimental, or the player has explicitly
+--- opted into experimental systems. `optIn` is the settings.experimentalSystems boolean.
+---@param systemId string
+---@param optIn boolean|nil
+---@return boolean
+function ReleaseGate.isReleased(systemId, optIn)
+    if not ReleaseGate.EXPERIMENTAL[systemId] then return true end
+    return optIn == true
+end
+
+--- The LIVE opt-in: reads the player's current settings.experimentalSystems value
+--- through the coordinator. Returns nil when the manager/settings are not
+--- available yet (pre-init or the offline test bench); callers decide what nil means.
+---@return boolean|nil
+function ReleaseGate.liveOptIn()
+    local mdm = g_MarketDynamics
+    if mdm and mdm.allowsExperimentalSystems then
+        return mdm:allowsExperimentalSystems()
+    end
+    return nil
+end
+
+--- A system is LIVE right now: released, or the player has opted in.
+--- FAIL-OPEN: when the live settings cannot be read (nil manager, nil settings, or
+--- a settings object without the predicate - e.g. the offline test bench), the
+--- system counts as live. The gate is an explicit opt-out of NEW systems; it must
+--- never silently disable a path just because the opt-in flag is not readable at
+--- that moment.
+---@param systemId string
+---@return boolean
+function ReleaseGate.isSystemLive(systemId)
+    local optIn = ReleaseGate.liveOptIn()
+    if optIn == nil then return true end
+    return ReleaseGate.isReleased(systemId, optIn)
+end
+
+--- Refusal message when a system is locked; nil when released.
+---@param systemId string
+---@param optIn boolean|nil
+---@return string|nil
+function ReleaseGate.lockMessage(systemId, optIn)
+    local entry = ReleaseGate.EXPERIMENTAL[systemId]
+    if not entry or optIn == true then return nil end
+    return string.format(
+        "Locked: %s is not released yet. Enable Experimental Systems to use it at your own risk.",
+        entry.name)
+end
+
+--- Console command gate. Mirrors the SF bypass-lock pattern but on the release axis.
+---@param commandName string
+---@param optIn boolean|nil
+---@return string|nil
+function ReleaseGate.commandLockMessage(commandName, optIn)
+    return ReleaseGate.lockMessage(ReleaseGate.COMMAND_TO_SYSTEM[commandName], optIn)
+end
+
+--- Player-friendly gate status, for the status/help surfaces and tests.
+---@param optIn boolean|nil
+---@return string
+function ReleaseGate.status(optIn)
+    local lines = { "=== Release gate ===" }
+    lines[#lines + 1] = string.format("  Experimental systems: %s",
+        optIn == true and "ON (at your own risk)" or "OFF (stable only)")
+    local on = optIn == true
+    if on then
+        lines[#lines + 1] = "  All experimental systems: ON"
+        for id, entry in pairs(ReleaseGate.EXPERIMENTAL) do
+            lines[#lines + 1] = string.format("    [ON] %s", entry.name)
+        end
+    else
+        lines[#lines + 1] = "  Not yet released:"
+        for id, entry in pairs(ReleaseGate.EXPERIMENTAL) do
+            lines[#lines + 1] = string.format("    [LOCKED] %s - %s", entry.name, entry.status)
+        end
+    end
+    return table.concat(lines, "\n")
+end
+
+MDMLog.info("Release gate loaded")

--- a/src/events/MDMSettingsSyncEvent.lua
+++ b/src/events/MDMSettingsSyncEvent.lua
@@ -48,6 +48,7 @@ function MDMSettingsSyncEvent:writeStream(streamId, connection)
     streamWriteBool(streamId, s.eventNotificationBanner == true)
     streamWriteBool(streamId, s.showContractHUD ~= false)
     streamWriteBool(streamId, s.useRealDays == true)
+    streamWriteBool(streamId, s.experimentalSystems == true)
 
     -- Disabled events
     local de = s.disabledEvents or {}
@@ -86,6 +87,7 @@ function MDMSettingsSyncEvent:readStream(streamId, connection)
         eventNotificationBanner = streamReadBool(streamId),
         showContractHUD = streamReadBool(streamId),
         useRealDays = streamReadBool(streamId),
+        experimentalSystems = streamReadBool(streamId),
         disabledEvents = {},
         eventCustomFillTypes = {},
     }

--- a/src/gui/SettingsUI.lua
+++ b/src/gui/SettingsUI.lua
@@ -112,6 +112,9 @@ local SETTING_DEFS = {
                                 descText  = "Show world events as a small corner banner instead of a pop-up dialog." },
     showContractHUD        = { label = "mdm_set_contract_hud",     desc = "mdm_desc_contract_hud",     type = "bool" },
     debugMode              = { label = "mdm_set_debug_mode",       desc = "mdm_desc_debug_mode",       type = "bool" },
+    experimentalSystems    = { label = "mdm_set_experimental",     desc = "mdm_desc_experimental",     type = "bool",
+                               labelText = "Experimental Systems",
+                               descText  = "Enable experimental (not yet released) systems at your own risk" },
 }
 
 -- ── Category definitions ───────────────────────────────────
@@ -133,7 +136,7 @@ local CATEGORIES = {
         accent   = {0.32, 0.88, 0.44, 1.0}, -- Green for sim
         sections = {
             { headerKey = "mdm_hdr_events",   items = { "eventsEnabled", "eventFrequency", "showEventNotifications", "eventNotificationBanner" } },
-            { headerKey = "mdm_hdr_display",  items = { "showContractHUD", "debugMode" } },
+            { headerKey = "mdm_hdr_display",  items = { "showContractHUD", "debugMode", "experimentalSystems" } },
         },
     },
 }


### PR DESCRIPTION
## Release gate mechanism (empty lock set)

Wires Arissani's certified 2026-08-03 lock set into Market Dynamics, mirroring the SoilFertilizer reference gate (PR #777).

### The ruling

Market Dynamics carries an EMPTY lock set today. The price-modifier contract is present but inert (its one adopter returns nil or 1.0 and changes no price), and OM-213 the organic premium is unbuilt and owed from the design side. It becomes a locked row when it is built. Nothing to gate today.

### What changed (mechanism only)

- **`src/ReleaseGate.lua`** (new): the release gate module with an empty registry. Same shape as SF's module: `isReleased`, `isSystemLive` (fail-open), `lockMessage`, `commandLockMessage`, `status`.
- **`experimentalSystems` setting**: default `false`, orthogonal to difficulty. Wired through the coordinator's settings table, `MarketSerializer` save/load, the MP `MDMSettingsSyncEvent` write/read, the SettingsHub mirror, and a settings-panel row.
- **`mdmRelease` console command**: prints the gate status (currently nothing locked).

Nothing is gated. Verification: all edited files parse as Lua 5.1; no in-mod test harness exists (noted). Not loaded in a game session.
