### PR TITLE
docs: note the release gate mechanism in ROADMAP and TODO

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - Baseline date: 2026-06-29 (updated 2026-07-25)
 
 ## Near-term (next release cycle)
+- [x] Release gate mechanism (2026-08-04): wired per Arissani's 2026-08-03 lock set (EMPTY for MDM - the price-modifier contract is inert, OM-213 is unbuilt and owed). `ReleaseGate.lua` with an empty registry, `experimentalSystems` opt-in (default false, orthogonal to difficulty) through settings/persistence/MP sync/SettingsHub/panel, and the `mdmRelease` status command. Nothing gated today.
 - [x] Witcombe join load-phase guard (ad958a0): load-phase flag prevents expire/restore/price-shift logic during MP join. Pushed 2026-07-28.
 - [~] Companion read API on `g_currentMission.MarketDynamics`: getActiveEvents() is live; getEligibleEvents() is still pending (ProStaff L20 early-warning). Price/trend reads to follow.
 - [x] StateLedger migration: `MarketDynamics_State` bridge live (b740771); own XML kept as the safety copy. Shipped v1.2.0.9.

--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,7 @@
 - [x] 2026-07-26 bug sweep: MDM auth gate, MDM persistence, MDM bcManaged bugs fixed and merged to main. All closed.
 
 ## Features / enhancements
+- [x] Release gate mechanism (2026-08-04): `ReleaseGate.lua` with an EMPTY registry (Arissani 2026-08-03). `experimentalSystems` opt-in (default false, orthogonal to difficulty) through the coordinator settings, `MarketSerializer` save/load, the MP `MDMSettingsSyncEvent`, the SettingsHub mirror and a settings-panel row. `mdmRelease` status command. Nothing gated; a row drops in the moment a system needs locking.
 - [ ] `getEligibleEvents()` to unblock ProStaff L20 early-warning (off-cooldown, not-active events).
 
 ## Cross-mod integration


### PR DESCRIPTION
## Follow-up to PR #105: ROADMAP/TODO note

PR #105 was merged before this commit landed on `development`. Carries commit `a3b6320`:

Documents the release gate mechanism wiring in ROADMAP.md and TODO.md. Docs only.
