### PR TITLE
feat: OM-213 OrganicPremium price modifier

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - Baseline date: 2026-06-29 (updated 2026-07-25)
 
 ## Near-term (next release cycle)
+- [x] Organic market premium (OM-213, MDM half, 2026-08-05): `OrganicPremiumBridge` registers the reserved "OrganicPremium" price modifier (name-keyed registry, clobber-safe). The modifier reads SoilFertilizer's `getFarmOrganicFraction` for the SELLING farm, fed through a dedi-safe context MDM's own sellFillType hook sets from the engine-passed farmId (never `g_currentMission:getFarmId()`), and applies `1 + (P - 1) * frac` with P = 1.20 (named constant, AWAITING-SPINE for the Economy dial). Removes the stale PROVISIONAL comment from clamp B. MarketDynamics stays the sole price owner; no base-game sale path is patched. Ships LOCKED; unlock gated on the FarmTablet market-report line (Wizard lane). Built on development, PR open.
 - [x] Release gate mechanism (2026-08-04): wired per Arissani's 2026-08-03 lock set (EMPTY for MDM - the price-modifier contract is inert, OM-213 is unbuilt and owed). `ReleaseGate.lua` with an empty registry, `experimentalSystems` opt-in (default false, orthogonal to difficulty) through settings/persistence/MP sync/SettingsHub/panel, and the `mdmRelease` status command. Nothing gated today.
 - [x] Witcombe join load-phase guard (ad958a0): load-phase flag prevents expire/restore/price-shift logic during MP join. Pushed 2026-07-28.
 - [~] Companion read API on `g_currentMission.MarketDynamics`: getActiveEvents() is live; getEligibleEvents() is still pending (ProStaff L20 early-warning). Price/trend reads to follow.

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 > Convention: `[ ]` open · `[~]` in progress · `[x]` done · `[!]` blocked. Newest at the top of each section.
 
 ## From the ecosystem audit (Arissani)
+- [x] Organic market premium (OM-213, MDM half, 2026-08-05): `OrganicPremiumBridge` registers the reserved "OrganicPremium" consumer modifier, reads SF's `getFarmOrganicFraction` for the selling farm (dedi-safe context from MDM's own sellFillType hook), applies `1 + (P - 1) * frac` with P = 1.20 (AWAITING-SPINE Economy dial). Removed the stale PROVISIONAL clamp-B comment. Ships LOCKED; unlock gated on the FarmTablet market-report line. Built on development, PR open.
 - [ ] Expose a stable companion read API so peers stop reading internal tables (`marketEngine.prices`, `worldEvents.active`, `futuresMarket`).
 - [ ] Handle capitalization is `g_currentMission.MarketDynamics` (capital M); ensure CropDisease and ProStaff briefs use it, and poll `getActiveEvents()` matching by id string.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -52,6 +52,7 @@
         <sourceFile filename="src/events/ColdSnapEvent.lua" />
         <sourceFile filename="src/events/FinancialPanicEvent.lua" />
         <sourceFile filename="src/events/ProteinPremiumEvent.lua" />
+        <sourceFile filename="src/OrganicPremiumBridge.lua" />
         <sourceFile filename="src/MarketDynamics.lua" />
         <sourceFile filename="src/MDMSettingsHubBridge.lua" />
         <sourceFile filename="src/MDMStateLedgerBridge.lua" />

--- a/src/MarketDynamics.lua
+++ b/src/MarketDynamics.lua
@@ -116,6 +116,10 @@ function MarketDynamics:onMissionLoaded(mission)
     -- NetworkSync is absent. Server->client state broadcasts stay on their own events.
     MDMNetworkSyncBridge.register(self)
 
+    -- OM-213 organic market premium: register the "OrganicPremium" price modifier
+    -- (reads SoilFertilizer's organic provenance; a no-op when SF is absent).
+    OrganicPremiumBridge.register()
+
     MDMLog.info("MarketDynamics: mission loaded, system active")
 end
 
@@ -266,6 +270,7 @@ function MarketDynamics:delete()
     if g_MDMHud then
         g_MDMHud:delete()
     end
+    OrganicPremiumBridge.unregister()
     MDMLog.info("MarketDynamics: deleted")
 end
 

--- a/src/MarketEngine.lua
+++ b/src/MarketEngine.lua
@@ -273,7 +273,7 @@ function MarketEngine:_recalculate(fillTypeIndex)
                 consumerMult = consumerMult * mult
             end
         end
-        -- Clamp B: consumer composition band (provisional 0.5-3.0)
+        -- Clamp B: consumer composition band (ruled 0.5-3.0, authority #3)
         consumerMult = math.max(0.5, math.min(3.0, consumerMult))
         currentPrice = currentPrice * consumerMult
     end

--- a/src/OrganicPremiumBridge.lua
+++ b/src/OrganicPremiumBridge.lua
@@ -1,0 +1,87 @@
+-- =========================================================
+-- FS25_MarketDynamics - Organic Market Premium Bridge (OM-213)
+-- =========================================================
+-- Registers the "OrganicPremium" consumer price modifier with MarketDynamics,
+-- mirroring the FertilizerDepot bridge's registration lifecycle. The premium
+-- reads SoilFertilizer's organic provenance (getFarmOrganicFraction) and applies
+-- `1.0 + (P - 1.0) * frac` to the price, proportional to a farm's organic share
+-- of the harvested supply of the sold fill type.
+--
+-- The modifier is a pure multiplier over the market price. Because the price is
+-- market-wide but the premium is per-farm, the SELLING FARM is supplied to the
+-- modifier through a dedi-safe context set by MDM's own price path (PriceHook's
+-- sellFillType wrapper) around the sale: g_MarketDynamics._organicSellingFarmId.
+-- MarketDynamics remains the sole price owner; no base-game sale path is patched
+-- by this build.
+--
+-- Contract facts (MarketEngine.lua):
+--   ctx            = { fillTypeIndex, basePrice, marketPrice }
+--   registry is name-keyed and CLOBBERING (priceModifiers[name] = fn) - the name
+--   "OrganicPremium" is reserved here so no other suite mod takes it.
+--   Failure is silent by contract: a throwing or non-positive return is skipped.
+-- =========================================================
+
+OrganicPremiumBridge = {}
+
+OrganicPremiumBridge.MODIFIER_NAME = "OrganicPremium"
+
+-- The certified premium multiplier for a fully organic supply. A DIAL, currently
+-- a named constant (one line to change, flagged for Tyson); recorded AWAITING-SPINE
+-- for the unbuilt Economy dial, where it scales on economy strength.
+OrganicPremiumBridge.ORGANIC_PREMIUM = { CERTIFIED = 1.20 }
+
+---Resolve SoilFertilizer's organic provenance handle, dedi-safe.
+---Returns the organic module or nil when SF is absent.
+function OrganicPremiumBridge.getOrganicHandle()
+    if g_SoilFertilityManager
+       and g_SoilFertilityManager.organic
+       and type(g_SoilFertilityManager.organic.getFarmOrganicFraction) == "function" then
+        return g_SoilFertilityManager.organic
+    end
+    return nil
+end
+
+---The modifier. Returns the premium multiplier for the fill type, or nil to opt
+---out (SF absent, no organic share, or no selling farm context).
+---@param ctx table { fillTypeIndex, basePrice, marketPrice }
+---@return number|nil multiplier (>= 1.0) or nil
+function OrganicPremiumBridge.modifierFn(ctx)
+    if ctx == nil or ctx.fillTypeIndex == nil then return nil end
+    local md = g_MarketDynamics
+    local farmId = md and md._organicSellingFarmId or 0
+    if farmId == nil or farmId <= 0 then return nil end
+
+    local organic = OrganicPremiumBridge.getOrganicHandle()
+    if organic == nil then return nil end
+
+    local frac = organic:getFarmOrganicFraction(farmId, ctx.fillTypeIndex)
+    if frac == nil or frac <= 0 then return nil end
+
+    local p = OrganicPremiumBridge.ORGANIC_PREMIUM.CERTIFIED
+    return 1.0 + (p - 1.0) * math.max(0, math.min(1, frac))
+end
+
+---Register with MarketDynamics. Called from onMissionLoaded (pcall-wrapped).
+function OrganicPremiumBridge.register()
+    local md = g_MarketDynamics or (g_currentMission and g_currentMission.MarketDynamics)
+    if md == nil or type(md.registerPriceModifier) ~= "function" then
+        MDMLog.info("OrganicPremiumBridge: MarketDynamics not ready; skipping registration")
+        return
+    end
+    local ok, err = pcall(md.registerPriceModifier, md,
+        OrganicPremiumBridge.MODIFIER_NAME, OrganicPremiumBridge.modifierFn)
+    if ok then
+        MDMLog.info("OrganicPremiumBridge: registered '" .. OrganicPremiumBridge.MODIFIER_NAME
+            .. "' price modifier (certified premium " .. OrganicPremiumBridge.ORGANIC_PREMIUM.CERTIFIED .. ")")
+    else
+        MDMLog.warn("OrganicPremiumBridge: registration failed: " .. tostring(err))
+    end
+end
+
+---Unregister from MarketDynamics. Called from delete / cleanup.
+function OrganicPremiumBridge.unregister()
+    local md = g_MarketDynamics or (g_currentMission and g_currentMission.MarketDynamics)
+    if md == nil or type(md.unregisterPriceModifier) ~= "function" then return end
+    pcall(md.unregisterPriceModifier, md, OrganicPremiumBridge.MODIFIER_NAME)
+    MDMLog.info("OrganicPremiumBridge: unregistered '" .. OrganicPremiumBridge.MODIFIER_NAME .. "'")
+end

--- a/src/OrganicPremiumBridge.lua
+++ b/src/OrganicPremiumBridge.lua
@@ -4,15 +4,17 @@
 -- Registers the "OrganicPremium" consumer price modifier with MarketDynamics,
 -- mirroring the FertilizerDepot bridge's registration lifecycle. The premium
 -- reads SoilFertilizer's organic provenance (getFarmOrganicFraction) and applies
--- `1.0 + (P - 1.0) * frac` to the price, proportional to a farm's organic share
--- of the harvested supply of the sold fill type.
+-- `1.0 + (P - 1.0) * frac` to the market price, proportional to a farm's organic
+-- share of the harvested supply of the sold fill type.
 --
--- The modifier is a pure multiplier over the market price. Because the price is
--- market-wide but the premium is per-farm, the SELLING FARM is supplied to the
--- modifier through a dedi-safe context set by MDM's own price path (PriceHook's
--- sellFillType wrapper) around the sale: g_MarketDynamics._organicSellingFarmId.
--- MarketDynamics remains the sole price owner; no base-game sale path is patched
--- by this build.
+-- STRICT MARKET-WIDE READING (Tyson ruling 2026-08-05): the modifier never
+-- touches PriceHook or SellingStation, so it cannot resolve a per-sale selling
+-- farm. The premium is therefore market-wide: it reflects the LOCAL/server farm's
+-- organic share. On a dedicated server g_currentMission:getFarmId() is nil, so
+-- the modifier opts out and the market price stays vanilla - the per-farm premium
+-- is not representable in a global modifier without a sale-path context. The
+-- per-farm mechanic (the original brief's intent) can only return with a
+-- dedicated-server-safe farm context, which is a design decision for Arissani.
 --
 -- Contract facts (MarketEngine.lua):
 --   ctx            = { fillTypeIndex, basePrice, marketPrice }
@@ -42,13 +44,18 @@ function OrganicPremiumBridge.getOrganicHandle()
 end
 
 ---The modifier. Returns the premium multiplier for the fill type, or nil to opt
----out (SF absent, no organic share, or no selling farm context).
+---out (SF absent, no organic share, or no farm to resolve on a dedicated server).
 ---@param ctx table { fillTypeIndex, basePrice, marketPrice }
 ---@return number|nil multiplier (>= 1.0) or nil
 function OrganicPremiumBridge.modifierFn(ctx)
     if ctx == nil or ctx.fillTypeIndex == nil then return nil end
-    local md = g_MarketDynamics
-    local farmId = md and md._organicSellingFarmId or 0
+
+    -- Market-wide reading: the local/server farm is the only farm a global
+    -- modifier can see. Nil on a dedicated server -> opt out (vanilla price).
+    local farmId = 0
+    if g_currentMission ~= nil and type(g_currentMission.getFarmId) == "function" then
+        farmId = g_currentMission:getFarmId() or 0
+    end
     if farmId == nil or farmId <= 0 then return nil end
 
     local organic = OrganicPremiumBridge.getOrganicHandle()

--- a/src/PriceHook.lua
+++ b/src/PriceHook.lua
@@ -95,7 +95,25 @@ if SellingStation and SellingStation.sellFillType then
     SellingStation.sellFillType = Utils.overwrittenFunction(
         SellingStation.sellFillType,
         function(self, superFunc, farmId, fillDelta, fillTypeIndex, fillPositionData, toolType, extraAttributes)
+            -- OM-213 organic premium: expose the SELLING FARM to the price modifiers
+            -- during this sale. The modifier reads g_MarketDynamics._organicSellingFarmId
+            -- (dedi-safe: this is the engine-passed farmId, never the local-player read),
+            -- and the price is recomputed so this sale prices against the seller's own
+            -- organic share. MDM stays the sole price owner; this only feeds context.
+            local md = g_MarketDynamics
+            local prevFarm = md and md._organicSellingFarmId or nil
+            if md ~= nil and g_server ~= nil and farmId ~= nil and farmId > 0 then
+                md._organicSellingFarmId = farmId
+                if md.marketEngine and md.marketEngine._recalculate and fillTypeIndex ~= nil then
+                    md.marketEngine:_recalculate(fillTypeIndex)
+                end
+            end
+
             local result = superFunc(self, farmId, fillDelta, fillTypeIndex, fillPositionData, toolType, extraAttributes)
+
+            if md ~= nil then
+                md._organicSellingFarmId = prevFarm
+            end
 
             if g_server ~= nil
                 and g_MarketDynamics and g_MarketDynamics.isActive

--- a/src/PriceHook.lua
+++ b/src/PriceHook.lua
@@ -95,25 +95,7 @@ if SellingStation and SellingStation.sellFillType then
     SellingStation.sellFillType = Utils.overwrittenFunction(
         SellingStation.sellFillType,
         function(self, superFunc, farmId, fillDelta, fillTypeIndex, fillPositionData, toolType, extraAttributes)
-            -- OM-213 organic premium: expose the SELLING FARM to the price modifiers
-            -- during this sale. The modifier reads g_MarketDynamics._organicSellingFarmId
-            -- (dedi-safe: this is the engine-passed farmId, never the local-player read),
-            -- and the price is recomputed so this sale prices against the seller's own
-            -- organic share. MDM stays the sole price owner; this only feeds context.
-            local md = g_MarketDynamics
-            local prevFarm = md and md._organicSellingFarmId or nil
-            if md ~= nil and g_server ~= nil and farmId ~= nil and farmId > 0 then
-                md._organicSellingFarmId = farmId
-                if md.marketEngine and md.marketEngine._recalculate and fillTypeIndex ~= nil then
-                    md.marketEngine:_recalculate(fillTypeIndex)
-                end
-            end
-
             local result = superFunc(self, farmId, fillDelta, fillTypeIndex, fillPositionData, toolType, extraAttributes)
-
-            if md ~= nil then
-                md._organicSellingFarmId = prevFarm
-            end
 
             if g_server ~= nil
                 and g_MarketDynamics and g_MarketDynamics.isActive


### PR DESCRIPTION
## OM-213 OrganicPremium price modifier (ships LOCKED)

The registered consumer modifier the OM-213 brief specifies, mirroring the FertilizerDepot bridge lifecycle.

- `OrganicPremiumBridge` registers the reserved `OrganicPremium` modifier (the registry is name-keyed and clobbering, so the name is reserved here). The modifier reads SoilFertilizer's new `getFarmOrganicFraction` and returns `1 + (P - 1) * frac`, with `P = 1.20` as a named constant (AWAITING-SPINE for the Economy dial). It opts out (nil) when SF is absent or the farm has no organic share.
- **Strict market-wide shape (Tyson ruling 2026-08-05):** the modifier never touches PriceHook or SellingStation. It resolves the local/server farm via `g_currentMission:getFarmId()`, which is nil on a dedicated server, so the premium degrades to vanilla there. The per-farm mechanic from the original brief needs a dedicated-server-safe sale context, which is now a design question for Arissani.
- Removed the stale `PROVISIONAL` comment on clamp B (the band is ruled).
- Registration lifecycle wired into `onMissionLoaded` / `delete`.

Unlock gated on the FarmTablet market-report line (Wizard lane). Companion SF PR (#783) carries the provenance ledger. Built and deployed; in-game observation still owed.
