### PR TITLE
fix: module page dots always visible on the Esc panel

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,3 +38,6 @@
 
 ## Deferred / parked
 - Event prediction / schedule API: parked by design. Events are probabilistic; peers poll active/eligible, they do not get a forecast.
+
+## 2026-08-07 (Fred): module page dots always visible
+- [x] The Esc RF module selector hid its page dots when Worker Costs or Market Dynamics was the active module. Soil and Crop Stress always showed theirs, so WC never read as the 3rd module and the left panel was inconsistent. All four RfPdaMenuPage copies now keep the dots visible (dots = N, chrome unchanged, per the esc-rf-pda umbrella brief). Built, deployed, PR open.

--- a/TODO.md
+++ b/TODO.md
@@ -39,3 +39,6 @@
 ## Esc panel buttons for MDM as door host (2026-08-07)
 - [x] MDM builds the shared Esc door (alphabetically first), so its RfPdaMenuPage now carries the bottom-bar button set for every module (Help, Rotation Planner, Field Detail, Open Worker Manager, Open full Market), with showWhenPaused and cross-mod resolution. Deployed and verified in-game.
 - [x] Help button shows only on the Soil module; other modules show Back only.
+
+## Module page dots always visible (2026-08-07)
+- [x] The Esc RF module page dots were hidden while Worker Costs or Market Dynamics was active, so WC never read as the 3rd module. All four RfPdaMenuPage copies now keep them visible. Built, deployed, PR open.

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -1203,8 +1203,8 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     setVis(self.wcSideVersion, false)
     setVis(self.mdSideInfoShell, isMd)
     setVis(self.rfSideInfoShell, isSoil or isCs)
-    -- On WC or MDM: hide Brand mid chrome so page sibling band owns that Y; Modules dock stays.
-    setVis(self.rfPanelDotBox, not isWc and not isMd)
+    -- Module page dots always visible (umbrella: dots = N, chrome geometry unchanged).
+    setVis(self.rfPanelDotBox, true)
     setVis(self.rfDotLegend, false)
     setVis(self.rfSuiteHint, false)
     setVis(self.rfSideMidSeparator, false)


### PR DESCRIPTION
The Esc RF module selector hides its page dots when Worker Costs or Market Dynamics is the active module. Soil and Crop Stress always showed theirs, so the left panel read inconsistently and WC never displayed as the 3rd module. The dots now stay visible for every module and stay in sync with the module selector (dots = N, per the esc-rf-pda umbrella brief).

Verified: built and deployed, Lua 5.1 syntax gate clean.