### PR TITLE
fix(esc): Crop Stress table flush - reclaim the 0-height action bar, drop the region toward the cards

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="106">
     <author>TisonK &amp; LeGrizzly</author>
-    <version>1.3.0.51</version>
+    <version>1.3.0.52</version>
     <title>
         <en>Market Dynamics</en>
     </title>

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -535,7 +535,7 @@
 
                     <!-- CS table: top-flush with 404 bottom reserve so the last rows clear the
                          FIELD DETAIL band title (CS FieldDetail fix, applied in the HOST page). -->
-                    <GuiElement profile="emptyPanel" id="csActionBar" position="0px 0px" size="1140px 44px">
+                    <GuiElement profile="emptyPanel" id="csActionBar" position="0px 0px" size="1140px 0px">
                         <!-- BUILD 18:48: this button owned the table-hiding consultant swap, which
                              is now a hard engine VETO. Hidden rather than deleted so any stale
                              binding still resolves; its job belongs to the Fields|Pivot subnav. -->
@@ -546,8 +546,8 @@
                     <!-- Inline Alex Chen consultant readout. Exclusive with rfHostTableRegion:
                          csBtnConsultant toggles which of the two is visible. Fixed Texts only -
                          George NO-GO on TextElement.new rebuild, dialog XML nest, or SmoothList. -->
-                    <GuiElement profile="RF_TableRegionShell" id="csConsultPanel" position="0px -44px"
-                                absoluteSizeOffset="0px 584px" visible="false">
+                    <GuiElement profile="RF_TableRegionShell" id="csConsultPanel" position="0px 0px"
+                                absoluteSizeOffset="0px 514px" visible="false">
                         <Text profile="RF_SectionTitle"   id="csConsTitle"    position="16px -12px"  size="700px 26px"  text=""/>
                         <Text profile="RF_TreatTargetLine" id="csConsRelation" position="16px -36px"  size="1140px 20px" visible="false" text=""/>
                         <Text profile="RF_ColHeader" id="csConsColField"    position="16px -64px"  size="280px 22px" text=""/>
@@ -582,8 +582,8 @@
                               textMaxNumLines="2" visible="false" text=""/>
                     </GuiElement>
 
-                    <GuiElement profile="RF_TableRegionShell" id="rfHostTableRegion" position="0px -44px"
-                                absoluteSizeOffset="0px 584px">
+                    <GuiElement profile="RF_TableRegionShell" id="rfHostTableRegion" position="0px 0px"
+                                absoluteSizeOffset="0px 514px">
                         <Text profile="RF_ColHeader" id="csColField" text="" position="16px -8px" size="100px 24px"/>
                         <Text profile="RF_ColHeader" id="csColCrop" text="" position="140px -8px" size="200px 24px"/>
                         <Text profile="RF_ColHeader" id="csColMoisture" text="" position="360px -8px" size="160px 24px"/>


### PR DESCRIPTION
csActionBar has held nothing but a hidden button since the table-hiding consultant swap
became an engine veto, so its 44px reserved space for nothing and started the Crop Stress
table 44px lower than it needed to. Height goes to 0 and the node stays, so any stale
csBtnConsultant binding still resolves.

rfHostTableRegion and its hidden twin csConsultPanel move to 0,0 and take
absoluteSizeOffset 514 instead of 584. RF_TableRegionShell stretches in Y, so the offset is
subtracted from the stretched height and a smaller offset is a taller region: 70px taller.
44 of those were already spent reclaiming the top, so 26px land at the bottom as new travel
toward the FIELD DETAIL and AGRONOMIST cards. Family rhythm, not a kiss.

FIELD DETAIL, AGRONOMIST and PIVOT are unmoved, and RF_CsDetailStrip is not grown.

The same page bytes go to all nine Esc doors on purpose. RfEscBootstrap.ensureDoor returns
early once the page exists, and whichever mod loads first builds it from its own copy, so a
change in one door alone is simply overwritten by whoever wins that race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)