### PR TITLE
Do not seed the market graph until the player has entered

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="106">
     <author>TisonK &amp; LeGrizzly</author>
-    <version>1.3.0.52</version>
+    <version>1.3.0.56</version>
     <title>
         <en>Market Dynamics</en>
     </title>

--- a/src/gui/MarketScreenGraph.lua
+++ b/src/gui/MarketScreenGraph.lua
@@ -36,6 +36,12 @@ end
 function MDMMarketScreenGraph.update(dt)
     if not g_MarketDynamics or not g_MarketDynamics.isActive then return end
 
+    -- BUILD 19:47: nothing is seeded or logged until the player has entered. The 19:20:43
+    -- flood happened during load, so a _loadPhase flag was not enough on its own; the guard
+    -- belongs inside this function, ahead of the sample timer, so no buffer is created and
+    -- no "seeded buffer" line is written while the machine is still compiling.
+    if not (g_currentMission ~= nil and g_currentMission.isMissionStarted == true) then return end
+
     _sampleTimer = _sampleTimer + dt
     if _sampleTimer < SAMPLE_INTERVAL_MS then return end
     _sampleTimer = _sampleTimer - SAMPLE_INTERVAL_MS


### PR DESCRIPTION
## Summary
- Guard the market graph update before the sample timer, so compile does not seed hundreds of prices.

## Test plan
- [ ] Dedicated join: no MarketScreenGraph seeded-buffer lines before the player has entered
- [ ] Start is a separate test; this PR does not claim Start is fixed