### PR TITLE
fix(mp): diff-aware world event sync

### DIFF
--- a/src/events/MDMMarketSyncEvent.lua
+++ b/src/events/MDMMarketSyncEvent.lua
@@ -114,35 +114,48 @@ function MDMMarketSyncEvent.applyState(prices, activeEvents)
     end
 
     if g_MarketDynamics.worldEvents then
-        -- Detect new events by comparing against current active list
+        local incoming = {}
+        for _, e in ipairs(activeEvents) do
+            incoming[e.id] = e
+        end
+
         local oldActive = {}
         for id, _ in pairs(g_MarketDynamics.worldEvents.active) do
             oldActive[id] = true
         end
 
-        -- Clear old events
-        for id, _ in pairs(g_MarketDynamics.worldEvents.active) do
-            g_MarketDynamics.worldEvents:_expireEvent(id, true)
+        -- Only expire events that are no longer in the incoming set
+        for id, _ in pairs(oldActive) do
+            if not incoming[id] then
+                g_MarketDynamics.worldEvents:_expireEvent(id)
+            end
         end
 
-        -- Load new events
         local newEventNames = {}
         for _, e in ipairs(activeEvents) do
-            g_MarketDynamics.worldEvents:loadActiveEvent(e.id, e.endsAt, e.intensity, e.extraData)
-            if g_MarketDynamics.worldEvents.isInitialized and not oldActive[e.id] then
-                local desc = g_MarketDynamics.worldEvents.registry[e.id]
-                local name = MDMUtil.resolveEventName(desc or e.id, desc and desc.name, e.id)
-                table.insert(newEventNames, name)
+            if oldActive[e.id] then
+                -- Already active: update timing silently without re-firing callbacks
+                local active = g_MarketDynamics.worldEvents.active[e.id]
+                if active then
+                    active.endsAt = e.endsAt
+                    active.intensity = e.intensity
+                end
+            else
+                -- Genuinely new event: full lifecycle
+                g_MarketDynamics.worldEvents:loadActiveEvent(e.id, e.endsAt, e.intensity, e.extraData)
+                if g_MarketDynamics.worldEvents.isInitialized then
+                    local desc = g_MarketDynamics.worldEvents.registry[e.id]
+                    local name = MDMUtil.resolveEventName(desc or e.id, desc and desc.name, e.id)
+                    table.insert(newEventNames, name)
+                end
             end
         end
 
         g_MarketDynamics.worldEvents.isInitialized = true
 
-        -- Show notification if we have new events (clients only)
         if #newEventNames > 0 then
             local names = table.concat(newEventNames, ", ")
             g_MarketDynamics.pendingEventNotificationName = names
-            -- Add a short delay (e.g. 1s) to ensure we're not colliding with other sync dialogs
             addTimer(1000, "showEventNotification", g_MarketDynamics)
         end
     end


### PR DESCRIPTION
## Summary
- `applyState()` was doing a full teardown/rebuild of ALL active world events on every market sync (every in-game minute), calling `onExpire` + `onFire`/`onLoad` callbacks and `UPIntegration` hooks for every active event each cycle
- Now diff-aware: only genuinely removed events get expired, only genuinely new events get loaded, already-active events just have their timing updated silently
- Eliminates the event spam flood and associated lag on multiplayer client join and during play

## Test plan
- [ ] Join a multiplayer server with active world events
- [ ] Verify no expire/restore log spam from `[MDM]` on join
- [ ] Verify active events display correctly in Market Screen Events tab
- [ ] Verify new events still trigger notifications when they fire
- [ ] Verify expired events are properly removed on client