### PR TITLE
feat(hud): base-game HUD theme, edge width resizing, and factory layout defaults

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -35,6 +35,7 @@
         <sourceFile filename="src/gui/MDMEventSettingsDialog.lua" />
         <sourceFile filename="src/gui/MDMEventFillTypeDialog.lua" />
         <sourceFile filename="src/gui/MDMBrowseFillTypesDialog.lua" />
+        <sourceFile filename="src/gui/MdPriceFormat.lua" />
         <sourceFile filename="src/gui/MarketScreenGraph.lua" />
         <sourceFile filename="src/gui/MarketScreen.lua" />
         <sourceFile filename="src/gui/RfEscModules.lua" />

--- a/src/MDMHUD.lua
+++ b/src/MDMHUD.lua
@@ -2,12 +2,12 @@
 -- On-screen HUD for tracking active futures contracts.
 -- Shows fill type, progress bar, delivery status, and time remaining.
 --
--- Visual style matches FS25_SoilFertilizer (clean, neutral, high-contrast).
--- Uses a single pixel overlay for efficient rendering.
+-- Visual style follows the base-game HUD extension and fill-level display.
+-- Falls back to a single pixel overlay when MasterHUD is unavailable.
 --
 -- Author: tison (dev-1)
 
-MDMHUD = {}
+MDMHUD = MDMHUD or {}
 local MDMHUD_mt = Class(MDMHUD)
 
 -- ── Base dimensions at scale 1.0 ─────────────────────────
@@ -17,7 +17,7 @@ MDMHUD.PAD    = 0.006
 
 -- ── Layout constants ─────────────────────────────────────
 MDMHUD.TITLE_H   = 0.022
-MDMHUD.BAR_H     = 0.008
+MDMHUD.BAR_H     = 0.005556
 MDMHUD.BAR_W     = 0.165
 MDMHUD.LINE_H    = 0.016
 
@@ -85,6 +85,11 @@ function MDMHUD:drawRect(x, y, w, h, c, a)
     renderOverlay(self.fillOverlay, x, y, w, h)
 end
 
+local function getBaseGameRenderer()
+    local hud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    return hud ~= nil and hud.renderer or nil
+end
+
 function MDMHUD:getIconOverlay(filename)
     if not filename or filename == "" then return nil end
     if not self.iconOverlays[filename] then
@@ -130,32 +135,26 @@ function MDMHUD:drawPanel(contract)
     local ph  = MDMHUD.BASE_H * s
     local pad = MDMHUD.PAD * s
 
-    -- Shadow
-    self:drawRect(px + 0.002*s, py - 0.002*s, pw, ph, MDMHUD.C_SHADOW)
-
-    -- Background
-    self:drawRect(px, py, pw, ph, MDMHUD.C_BG)
-
-    -- Header / Title Bar
     local titleH = MDMHUD.TITLE_H * s
-    self:drawRect(px, py + ph - titleH, pw, titleH, MDMHUD.C_TITLE_BG)
+    local renderer = getBaseGameRenderer()
+    local usedNativePanel = renderer ~= nil and renderer.renderPanel ~= nil
+        and renderer:renderPanel(px, py, pw, ph)
+    if not usedNativePanel then
+        -- Compatibility fallback for standalone use without MasterHUD.
+        self:drawRect(px + 0.002*s, py - 0.002*s, pw, ph, MDMHUD.C_SHADOW)
+        self:drawRect(px, py, pw, ph, MDMHUD.C_BG)
+        self:drawRect(px, py + ph - titleH, pw, titleH, MDMHUD.C_TITLE_BG)
 
-    -- Border
-    local bw = 0.0006 * s
-    self:drawRect(px,           py,            pw, bw, MDMHUD.C_BORDER)
-    self:drawRect(px,           py + ph - bw,   pw, bw, MDMHUD.C_BORDER)
-    self:drawRect(px,           py,            bw, ph, MDMHUD.C_BORDER)
-    self:drawRect(px + pw - bw,  py,            bw, ph, MDMHUD.C_BORDER)
+        local bw = 0.0006 * s
+        self:drawRect(px,           py,            pw, bw, MDMHUD.C_BORDER)
+        self:drawRect(px,           py + ph - bw,   pw, bw, MDMHUD.C_BORDER)
+        self:drawRect(px,           py,            bw, ph, MDMHUD.C_BORDER)
+        self:drawRect(px + pw - bw,  py,            bw, ph, MDMHUD.C_BORDER)
+    end
 
-    -- Title text in header bar
-    local titleLabel = g_i18n:getText("mdm_hud_title") or "Market Watch"
-    local titleCX = px + pw * 0.5
-    setTextBold(true)
-    setTextColor(0.72, 0.72, 0.72, 1.0)
-    setTextAlignment(RenderText.ALIGN_CENTER)
-    renderText(titleCX, py + ph - titleH * 0.5 - 0.005 * s, 0.009 * s, titleLabel)
-
-    -- ── Content ───────────────────────────────────────────
+    -- The crop and completion value are the header row, matching the native
+    -- fill-level panel. A second generic title used to occupy this exact same
+    -- baseline and overprint both values.
     local tx = px + pad
     local ty = py + ph - titleH * 0.5
     
@@ -195,9 +194,14 @@ function MDMHUD:drawPanel(contract)
     -- Progress Bar
     local barX = px + (pw - MDMHUD.BAR_W * s) * 0.5
     local barY = cy - MDMHUD.BAR_H * s
-    self:drawRect(barX, barY, MDMHUD.BAR_W * s, MDMHUD.BAR_H * s, MDMHUD.C_BAR_BG)
-    if pct > 0 then
-        self:drawRect(barX, barY, MDMHUD.BAR_W * s * math.min(1, pct), MDMHUD.BAR_H * s, MDMHUD.C_MDM_GREEN)
+    local usedNativeBar = renderer ~= nil and renderer.renderProgressBar ~= nil
+        and renderer:renderProgressBar(barX, barY, MDMHUD.BAR_W * s,
+            MDMHUD.BAR_H * s, pct, MDMHUD.C_MDM_GREEN)
+    if not usedNativeBar then
+        self:drawRect(barX, barY, MDMHUD.BAR_W * s, MDMHUD.BAR_H * s, MDMHUD.C_BAR_BG)
+        if pct > 0 then
+            self:drawRect(barX, barY, MDMHUD.BAR_W * s * math.min(1, pct), MDMHUD.BAR_H * s, MDMHUD.C_MDM_GREEN)
+        end
     end
     
     cy = barY - pad * 1.2
@@ -290,5 +294,14 @@ function MDMHUD:scrollEvent(posX, posY, button)
     end
 end
 
--- Global singleton
-g_MDMHud = MDMHUD.new()
+-- Global singleton. Preserve and patch the live instance during script reloads.
+if g_MDMHud == nil then
+    g_MDMHud = MDMHUD.new()
+else
+    for key, value in pairs(MDMHUD) do
+        if type(value) == "function" then
+            g_MDMHud[key] = value
+        end
+    end
+    print("[MarketDynamics] MDMHUD live instance patched")
+end

--- a/src/MarketDynamics.lua
+++ b/src/MarketDynamics.lua
@@ -314,7 +314,20 @@ end
 -- UI Helpers
 -- ---------------------------------------------------------------------------
 
----Shows a YesNoDialog when a world event starts.
+---Announce a world event on the suite's non-blocking notice channel.
+---
+--- BUILD 15:39 (PB-13). This used to default to a YesNoDialog asking whether to
+--- open the Market Screen. A world event starting is not a player decision - the
+--- event fires either way and the answer changes nothing about the world - so
+--- the modal bought nothing and cost a full-screen dim, a focus steal and a
+--- pause, three times in one of Brian's short sessions, on top of an open
+--- console. DESIGN 15:00 §6 retires it: every current market event uses the
+--- non-blocking line, and no market event qualifies to escalate to a modal.
+---
+--- Pacing, folding and the queue-while-covered rule all live in MasterHUD's
+--- shared notice queue, so Market Dynamics decides only what to say. Without
+--- MasterHUD the mod still ships standalone and falls back to the game's own
+--- notification list - never back to a dialog.
 ---@param eventListString string Concatenated list of event names.
 function MarketDynamics:showEventNotification(eventListString)
     -- If eventListString is not a string (e.g. nil or self from addTimer), 
@@ -344,30 +357,31 @@ function MarketDynamics:showEventNotification(eventListString)
     -- getText returns truthy "Missing '…'" when l10n failed to load; never paint that.
     local title = (MDMUtil and MDMUtil.getModText("mdm_screen_title")) or "Market Dynamics"
 
-    if self.settings.eventNotificationBanner then
-        -- Discreet, non-modal banner: a quiet in-game notification in the corner
-        -- instead of a full-screen modal that dims everything black. Preferred while
-        -- driving or working a field (issue #94). The active event is also listed in
-        -- the Market Screen's Events tab.
-        local msg = string.format("%s: %s", title, eventListString)
-        if g_currentMission and g_currentMission.addIngameNotification then
-            g_currentMission:addIngameNotification(FSBaseMission.INGAME_NOTIFICATION_INFO, msg)
-            MDMLog.info("MarketDynamics: event notification banner shown")
-        else
-            MDMLog.warn("MarketDynamics: addIngameNotification unavailable — notification skipped")
-        end
-    else
-        -- Full pop-up dialog (default): asks whether to open the Market Screen.
-        local fmt = (MDMUtil and MDMUtil.getModText("mdm_msg_event_started"))
-            or "A new world event has started: %s\n\nWould you like to open the Market Screen to see the impact?"
-        local text = string.format(fmt, eventListString)
+    -- One line, no question. The event is already listed on the Market Screen's
+    -- Events tab, which is where a player who wants the detail goes.
+    local msg = string.format("%s: %s", title, eventListString)
 
-        MDMLog.info("MarketDynamics: calling YesNoDialog.show")
-        YesNoDialog.show(function(yes)
-            if yes then
-                MDMMarketScreen.show()
-            end
-        end, nil, text, title)
+    -- Preferred path: the suite's shared queue. It is the thing that guarantees
+    -- one line per in-game-day window, folds a burst into "+N more today", and
+    -- stays silent while the tablet or the Esc menu is up.
+    local hud = (g_currentMission and g_currentMission.masterHUD) or g_masterHUD
+    if hud ~= nil and type(hud.postNotice) == "function" then
+        local ok, posted = pcall(hud.postNotice, hud, {
+            topic = "mdm_world_event",
+            text  = msg,
+        })
+        if ok and posted then
+            MDMLog.info("MarketDynamics: event notice queued on the shared channel")
+            return
+        end
+    end
+
+    -- Standalone fallback: still non-blocking, still not a dialog.
+    if g_currentMission and g_currentMission.addIngameNotification then
+        g_currentMission:addIngameNotification(FSBaseMission.INGAME_NOTIFICATION_INFO, msg)
+        MDMLog.info("MarketDynamics: event notification shown (no MasterHUD)")
+    else
+        MDMLog.warn("MarketDynamics: addIngameNotification unavailable - notification skipped")
     end
 end
 

--- a/src/gui/MDMEventSettingsDialog.lua
+++ b/src/gui/MDMEventSettingsDialog.lua
@@ -88,7 +88,10 @@ function MDMEventSettingsDialog:onGuiSetupFinished()
     self.freqHighTxt   = self:getDescendantById("evtFreqHighTxt")
 
     -- Fill type reference hint
-    self.fillTypeHint = self:getDescendantById("evtSFillTypeHint")
+    self.fillTypeHint  = self:getDescendantById("evtSFillTypeHint")
+    -- BUILD 15:39 (PB-08): dev-only Test column header.
+    self.colHdrTest    = self:getDescendantById("evtSColHdrTest")
+    self.fillTypeLabel = self:getDescendantById("evtSFillTypeLabel")
 
     -- Per-event rows
     for i = 0, MAX_EVENT_ROWS - 1 do
@@ -261,13 +264,81 @@ end
 
 -- ── Fill type reference hint ──────────────────────────────────────────────────
 
--- Populate the "TRACKED FILL TYPES" section at the bottom of the dialog with
--- every fill type currently tracked by MarketEngine (vanilla + all mod crops).
--- Players use this as a reference when typing names into the fill type editor.
+--- BUILD 15:39 (PB-08). Is this dialog being shown on a developer surface?
+---
+--- `settings.debugMode` is the player-visible developer switch Market Dynamics
+--- already ships (Settings ▸ Display ▸ Debug Mode). Off, which is the default
+--- and what every normal save runs, this is a player surface: no dev triggers,
+--- no internal identifiers. On, the developer view comes back in full.
+---@return boolean
+function MDMEventSettingsDialog:_isDevSurface()
+    local s = g_MarketDynamics and g_MarketDynamics.settings
+    return s ~= nil and s.debugMode == true
+end
+
+-- Populate the tracked-fill-type section at the bottom of the dialog.
+--
+-- BUILD 15:39 (PB-08). This used to print every tracked fill type's INTERNAL
+-- name, sorted and dot-joined - a long line of raw uppercase-ish engine keys
+-- that ran past the edge of its box and truncated mid-token. That is a
+-- developer reference on a player screen. Players now get the plain categories
+-- the engine tracks and a count; the raw key list is still there verbatim on the
+-- dev surface, because typing a name into the fill type editor is exactly the
+-- job it was written for.
 function MDMEventSettingsDialog:_refreshFillTypeHint()
     if not self.fillTypeHint then return end
-    local list = self:_buildAvailableFillTypeList()
-    self.fillTypeHint:setText(list ~= "" and list or "—")
+    if self:_isDevSurface() then
+        local list = self:_buildAvailableFillTypeList()
+        self.fillTypeHint:setText(list ~= "" and list or "-")
+        return
+    end
+    self.fillTypeHint:setText(self:_buildTrackedCategorySummary())
+end
+
+--- Player-language summary: which categories are tracked, and how many types.
+--- Categories come from the fill type's own title, never its internal name.
+function MDMEventSettingsDialog:_buildTrackedCategorySummary()
+    if not g_fillTypeManager or not g_MarketDynamics then return "-" end
+    local engine = g_MarketDynamics.marketEngine
+    if engine == nil or engine.prices == nil then return "-" end
+
+    -- The categories Market Dynamics prices, in the order a player thinks about
+    -- them. `match` is checked against the fill type's own category/name, so a
+    -- mod crop lands in Crops rather than in a bucket of its own.
+    local CATEGORIES = {
+        { key = "mdm_cat_crops",     fb = "Crops",     n = 0 },
+        { key = "mdm_cat_silage",    fb = "Silage",    n = 0 },
+        { key = "mdm_cat_livestock", fb = "Livestock", n = 0 },
+        { key = "mdm_cat_other",     fb = "Other",     n = 0 },
+    }
+    local SILAGE    = { silage = true, chaff = true, grass_windrow = true, drygrass_windrow = true, hay = true, straw = true }
+    local LIVESTOCK = { cow = true, sheep = true, pig = true, chicken = true, horse = true, goat = true, milk = true, egg = true, wool = true }
+
+    local total = 0
+    for _, ft in ipairs(g_fillTypeManager:getFillTypes()) do
+        if ft and ft.index and ft.index > 1 and ft.name and ft.name ~= ""
+           and engine.prices[ft.index] then
+            total = total + 1
+            local n = string.lower(ft.name)
+            local slot
+            if LIVESTOCK[n] then slot = 3
+            elseif SILAGE[n] then slot = 2
+            elseif ft.showOnPriceTable ~= false then slot = 1
+            else slot = 4 end
+            CATEGORIES[slot].n = CATEGORIES[slot].n + 1
+        end
+    end
+
+    if total == 0 then return "-" end
+
+    local parts = {}
+    for _, c in ipairs(CATEGORIES) do
+        if c.n > 0 then
+            local label = (g_i18n and g_i18n:hasText(c.key)) and g_i18n:getText(c.key) or c.fb
+            table.insert(parts, string.format("%s (%d)", label, c.n))
+        end
+    end
+    return table.concat(parts, "   ")
 end
 
 function MDMEventSettingsDialog:_buildAvailableFillTypeList()
@@ -287,6 +358,11 @@ end
 -- ── Per-event rows ────────────────────────────────────────────────────────────
 
 function MDMEventSettingsDialog:_refreshEventRows()
+    -- BUILD 15:39 (PB-08): the Test column header follows its buttons.
+    if self.colHdrTest ~= nil then
+        self.colHdrTest:setVisible(self:_isDevSurface())
+    end
+
     local s        = g_MarketDynamics and g_MarketDynamics.settings
     local disabled = (s and s.disabledEvents)         or {}
     local cft      = (s and s.eventCustomFillTypes)   or {}
@@ -301,8 +377,15 @@ function MDMEventSettingsDialog:_refreshEventRows()
         local function setVis(el) if el then el:setVisible(hasRow) end end
         setVis(self.rowNames[i]);    setVis(self.rowTogBgs[i]);   setVis(self.rowTogBtns[i])
         setVis(self.rowTogTxts[i]);  setVis(self.rowCounts[i]);   setVis(self.rowEditBgs[i])
-        setVis(self.rowEditBtns[i]); setVis(self.rowEditTxts[i]); setVis(self.rowForceBgs[i])
-        setVis(self.rowForceBtns[i]); setVis(self.rowForceTxts[i])
+        setVis(self.rowEditBtns[i]); setVis(self.rowEditTxts[i])
+
+        -- BUILD 15:39 (PB-08). The Test column is a developer trigger: it fires
+        -- a world event at full intensity on demand. It stays on the dev surface
+        -- and is not shipped to players. `mdmForceEvent` in AdminCommands is the
+        -- unchanged console route, so nothing is lost for the people who use it.
+        local devSurface = self:_isDevSurface()
+        local function setDevVis(el) if el then el:setVisible(hasRow and devSurface) end end
+        setDevVis(self.rowForceBgs[i]); setDevVis(self.rowForceBtns[i]); setDevVis(self.rowForceTxts[i])
 
         if hasRow then
             local id          = entry.id
@@ -408,6 +491,14 @@ end
 
 -- Force-fire if the event is idle; force-expire if it is currently active.
 function MDMEventSettingsDialog:_handleForce(rowIndex)
+    -- BUILD 15:39 (PB-08). The buttons are hidden off the dev surface, but the
+    -- onClick callbacks still exist on the dialog, so the gate is enforced here
+    -- too rather than relying on the control being invisible.
+    if not self:_isDevSurface() then
+        MDMLog.info("MDMEventSettingsDialog: force ignored (player surface; use mdmForceEvent)")
+        return
+    end
+
     local entry = self._eventOrder[rowIndex + 1]
     if not entry or not g_MarketDynamics then return end
 

--- a/src/gui/MarketScreen.lua
+++ b/src/gui/MarketScreen.lua
@@ -275,6 +275,13 @@ function MDMMarketScreen:onGuiSetupFinished()
     self.tabLabelEvents    = self:getDescendantById("tabLabelEvents")
     self.tabLabelContracts = self:getDescendantById("tabLabelContracts")
 
+    -- BUILD 15:39 (PB-04): the invisible hit rects, resolved so the fallback
+    -- hit-test can check the control the engine actually dispatches, not just
+    -- the label drawn over it.
+    self.tabHitPrices      = self:getDescendantById("tabHitPrices")
+    self.tabHitEvents      = self:getDescendantById("tabHitEvents")
+    self.tabHitContracts   = self:getDescendantById("tabHitContracts")
+
     self.tabUnderlinePrices    = self:getDescendantById("tabUnderlinePrices")
     self.tabUnderlineEvents    = self:getDescendantById("tabUnderlineEvents")
     self.tabUnderlineContracts = self:getDescendantById("tabUnderlineContracts")
@@ -630,20 +637,30 @@ function MDMMarketScreen:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     end
 
     if isDown and button == Input.MOUSE_BUTTON_LEFT then
+        -- BUILD 15:39 (PB-04). Both the visible label AND its co-located hit
+        -- Button are tested. The label rect is what the player aims at; the
+        -- Button rect is what the engine dispatches. They now describe the same
+        -- box in the XML, so either one landing is a real tab click, and a click
+        -- can no longer fall between them the way it did for Events/Contracts.
         local tabs = {
-            { el = self.tabLabelPrices,    cb = MDMMarketScreen.onClickTabPrices    },
-            { el = self.tabLabelEvents,    cb = MDMMarketScreen.onClickTabEvents    },
-            { el = self.tabLabelContracts, cb = MDMMarketScreen.onClickTabContracts },
+            { els = { self.tabLabelPrices,    self.tabHitPrices    }, name = "PRICES",
+              cb = MDMMarketScreen.onClickTabPrices    },
+            { els = { self.tabLabelEvents,    self.tabHitEvents    }, name = "EVENTS",
+              cb = MDMMarketScreen.onClickTabEvents    },
+            { els = { self.tabLabelContracts, self.tabHitContracts }, name = "CONTRACTS",
+              cb = MDMMarketScreen.onClickTabContracts },
         }
         for _, t in ipairs(tabs) do
-            if t.el then
-                local ap = t.el.absPosition
-                local as = t.el.absSize
-                if ap and as and
-                   posX >= ap[1] and posX <= ap[1] + as[1] and
-                   posY >= ap[2] and posY <= ap[2] + as[2] then
-                    t.cb(self)
-                    return true
+            for _, el in ipairs(t.els) do
+                if el then
+                    local ap = el.absPosition
+                    local as = el.absSize
+                    if ap and as and
+                       posX >= ap[1] and posX <= ap[1] + as[1] and
+                       posY >= ap[2] and posY <= ap[2] + as[2] then
+                        t.cb(self)
+                        return true
+                    end
                 end
             end
         end
@@ -737,6 +754,101 @@ function MDMMarketScreen:rebuildAllData()
     self:_buildContractData()
 end
 
+-- ---------------------------------------------------------------------------
+-- BUILD 15:39 (PB-07) - price and label display
+--
+-- Brian read this table and could not use it: two rows both said "Alfalfa", long
+-- names ran into the price column, and livestock priced per animal was printed
+-- as `$9578936 / 1,000L` because every row was multiplied by 1000 and given a
+-- litre suffix.
+--
+-- Formats follow George's ENGINE ruling of 2026-08-15, which is sourced from the
+-- I18N decompile rather than from the wiki (there is no I18N wiki page):
+--   formatNumber(number, precision, forcePrecision)
+--   formatMoney(number, precision, addCurrency, prefixCurrencySymbol)
+-- formatMoney does NOT forward forcePrecision, so `formatMoney(12, 2)` can print
+-- "12" and not "12.00". Forced two places therefore go through
+-- formatNumber(v, 2, true) plus the short currency symbol.
+--
+-- The animal test is `animalSystem:getSubTypeByFillTypeIndex`, also from that
+-- ruling - no invented flags, and milk / wool / eggs stay on litre pricing
+-- because they are produce, not livestock.
+--
+-- Only the DISPLAY changes. entry.current stays the per-litre engine number that
+-- contracts, the price hook and the graph samples all read.
+-- ---------------------------------------------------------------------------
+
+--- Short currency symbol, falling back to the bare number rather than to a
+--- hardcoded "$" (the old format was wrong in every non-dollar locale).
+local function currency()
+    if g_i18n ~= nil and type(g_i18n.getCurrencySymbol) == "function" then
+        local ok, sym = pcall(g_i18n.getCurrencySymbol, g_i18n, true)
+        if ok and type(sym) == "string" and sym ~= "" then return sym end
+    end
+    return ""
+end
+
+--- Grouped, forced-2dp money. Never `%.0f`.
+local function money2(value)
+    local n
+    if g_i18n ~= nil and type(g_i18n.formatNumber) == "function" then
+        local ok, s = pcall(g_i18n.formatNumber, g_i18n, value, 2, true)
+        if ok and type(s) == "string" then n = s end
+    end
+    if n == nil then n = string.format("%.2f", value or 0) end
+    local sym = currency()
+    if sym == "" then return n end
+    return sym .. n
+end
+
+--- Is this fill type sold as live animals rather than by the litre?
+--- Guarded by type checks: if the engine ever drops the accessor this returns
+--- false and the row keeps its existing litre formatting instead of throwing.
+function MDMMarketScreen:_isLivestock(fillTypeIndex)
+    local sys = g_currentMission ~= nil and g_currentMission.animalSystem or nil
+    if sys == nil or type(sys.getSubTypeByFillTypeIndex) ~= "function" then
+        return false
+    end
+    local ok, subType = pcall(sys.getSubTypeByFillTypeIndex, sys, fillTypeIndex)
+    return ok and subType ~= nil
+end
+
+--- The player-facing price for one commodity row.
+--- Litre rows: price per 1,000 L. Livestock rows: price per head, no * 1000 and
+--- no litre suffix - that multiplication is what produced Brian's `$9578936`.
+function MDMMarketScreen:_priceText(data)
+    if data == nil then return "" end
+    if data.isLivestock then
+        local per = MDMUtil and MDMUtil.getModText("mdm_screen_per_head")
+        if type(per) ~= "string" or per == "" then per = "/ head" end
+        return money2(data.current or 0) .. " " .. per
+    end
+    local per = MDMUtil and MDMUtil.getModText("mdm_screen_per_1000l")
+    if type(per) ~= "string" or per == "" then per = "/ 1,000L" end
+    return money2((data.current or 0) * 1000) .. " " .. per
+end
+
+--- Give every row a label a player can tell apart.
+---
+--- Two fill types can legitimately share a display title (`Alfalfa` the crop and
+--- `Alfalfa hay` the windrow both localise to "Alfalfa" on some maps). Where that
+--- happens the internal fill-type name is appended as a parenthetical hint - only
+--- for the rows that actually collide, so a unique row is never made noisier.
+local function disambiguate(list)
+    local seen = {}
+    for _, row in ipairs(list) do
+        local t = row.title or ""
+        seen[t] = (seen[t] or 0) + 1
+    end
+    for _, row in ipairs(list) do
+        if (seen[row.title or ""] or 0) > 1 and row.name ~= nil and row.name ~= "" then
+            -- "ALFALFA_HAY" reads worse than "alfalfa hay" next to a title.
+            local hint = string.lower(tostring(row.name)):gsub("_", " ")
+            row.title = string.format("%s (%s)", row.title, hint)
+        end
+    end
+end
+
 function MDMMarketScreen:_buildCommodityData()
     self.commodities = {}
 
@@ -760,13 +872,25 @@ function MDMMarketScreen:_buildCommodityData()
                 volatility = entry.volatilityFactor,
                 modifiers  = entry.modifiers,
                 hudOverlay = fillType.hudOverlayFilename,
+                -- Resolved once here rather than per draw frame.
+                isLivestock = self:_isLivestock(fillTypeIndex),
             })
         end
     end
 
+    disambiguate(self.commodities)
+
     local sortField = self.sortField
     local sortAsc   = self.sortAscending
     table.sort(self.commodities, function(a, b)
+        -- BUILD 15:39 (PB-07). Livestock is priced per head and crops per
+        -- 1,000 L, so interleaving them puts two incomparable units in one
+        -- column and invites exactly the misreading Brian reported. Livestock
+        -- sorts into its own contiguous block at the end, under whichever sort
+        -- the player picked; the ordering INSIDE each block is unchanged.
+        if (a.isLivestock == true) ~= (b.isLivestock == true) then
+            return b.isLivestock == true
+        end
         if sortField == SORT_PRICE then
             local ac, bc = a.current or 0, b.current or 0
             if sortAsc then return ac < bc else return ac > bc end
@@ -932,7 +1056,7 @@ function MDMMarketScreen:_populateCommodityCell(index, cell)
         nameEl:setText(data.title)
     end
     if priceEl then
-        priceEl:setText(string.format("$%.0f / 1,000L", data.current * 1000))
+        priceEl:setText(self:_priceText(data))
     end
     if changeEl then
         local sign = data.changePct >= 0 and "+" or ""
@@ -1017,7 +1141,9 @@ function MDMMarketScreen:_populateContractCell(index, cell)
         qtyEl:setText(string.format(fmt, data.quantity))
     end
     if priceEl then
-        priceEl:setText(string.format("$%.0f / 1,000L", data.lockedPrice * 1000))
+        -- BUILD 15:39 (PB-07): grouped, forced 2dp, locale currency. A contract
+        -- is always a litre quantity, so this row keeps the per-1,000L unit.
+        priceEl:setText(self:_priceText({ current = data.lockedPrice, isLivestock = false }))
     end
     if progressEl then
         local pct = 0
@@ -1082,13 +1208,15 @@ function MDMMarketScreen:refreshPricesDetail()
     if self.detailCurrentPrice then
         self.detailCurrentPrice:setText(
             g_i18n:getText("mdm_screen_current_price") .. ": " ..
-            string.format("$%.0f / 1,000L", crop.current * 1000)
+            self:_priceText(crop)
         )
     end
     if self.detailBasePrice then
         self.detailBasePrice:setText(
             g_i18n:getText("mdm_screen_base_price") .. ": " ..
-            string.format("$%.0f / 1,000L", crop.base * 1000)
+            -- Same unit as the row it came from, so a livestock selection never
+            -- shows per head in the table and per 1,000L in the detail card.
+            self:_priceText({ current = crop.base, isLivestock = crop.isLivestock })
         )
     end
     if self.detailChange then

--- a/src/gui/MarketScreenGraph.lua
+++ b/src/gui/MarketScreenGraph.lua
@@ -153,7 +153,12 @@ function MDMMarketScreenGraph.draw(fillTypeIndex, gx, gy, gw, gh)
     local ordered = _extractOrdered(buf)
     if #ordered < 2 then return end
 
-    MDMMarketScreenGraph._drawLineChart(ordered, gx, gy, gw, gh)
+    -- BUILD 15:39 (PB-07): name the series and its unit so the chart is
+    -- readable on its own instead of being an unlabelled line.
+    MDMMarketScreenGraph._drawLineChart(ordered, gx, gy, gw, gh, {
+        label   = MDMMarketScreenGraph._fillTypeTitle(fillTypeIndex),
+        perHead = MDMMarketScreenGraph._isLivestock(fillTypeIndex),
+    })
 end
 
 --- BUILD 23:43: the ONE price-trend decision tree, shared by the full Market screen and
@@ -200,7 +205,10 @@ function MDMMarketScreenGraph.drawPriceTrend(fillTypeIndex, gx, gy, gw, gh)
                     end
                 end
                 if #series >= 2 then
-                    MDMMarketScreenGraph._drawLineChart(series, gx, gy, gw, gh)
+                    MDMMarketScreenGraph._drawLineChart(series, gx, gy, gw, gh, {
+                        label   = MDMMarketScreenGraph._fillTypeTitle(fillTypeIndex),
+                        perHead = MDMMarketScreenGraph._isLivestock(fillTypeIndex),
+                    })
                     return "history"
                 end
             end
@@ -247,7 +255,13 @@ function MDMMarketScreenGraph.drawAggregatedMedian(gx, gy, gw, gh)
 
     if #agg < 2 then return end
 
-    MDMMarketScreenGraph._drawLineChart(agg, gx, gy, gw, gh)
+    -- The median across every tracked commodity is not one commodity, and
+    -- labelling it with a crop name would be a lie about what is plotted.
+    local medianLabel = MDMUtil and MDMUtil.getModText("mdm_screen_graph_median")
+    if type(medianLabel) ~= "string" or medianLabel == "" then
+        medianLabel = "All commodities (median)"
+    end
+    MDMMarketScreenGraph._drawLineChart(agg, gx, gy, gw, gh, { label = medianLabel })
 end
 
 -- ---------------------------------------------------------------------------
@@ -269,9 +283,72 @@ end
 -- Line chart renderer (core) — uses drawFilledRect + drawLine2D
 -- ---------------------------------------------------------------------------
 
-function MDMMarketScreenGraph._drawLineChart(series, gx, gy, gw, gh)
+-- BUILD 15:39 (PB-07) - graph context.
+--
+-- The chart drew a line and five bare Y numbers. Brian could not tell which
+-- commodity it was, over what period, or in what unit, which makes the trend
+-- unreadable however correct the line is. These helpers add the missing frame:
+-- the selected commodity's name, the x-axis time window, and Y labels that agree
+-- with the table's units and 2dp.
+--
+-- Nothing here invents data. The label comes from the fill type the caller
+-- already resolved, and the window is described from the sample count that is
+-- actually plotted - never a fabricated date range or a padded flat point.
+
+local function graphCurrency()
+    if g_i18n ~= nil and type(g_i18n.getCurrencySymbol) == "function" then
+        local ok, sym = pcall(g_i18n.getCurrencySymbol, g_i18n, true)
+        if ok and type(sym) == "string" and sym ~= "" then return sym end
+    end
+    return ""
+end
+
+--- Grouped, forced-2dp axis money. Matches the table (George ENGINE 2026-08-15:
+--- formatMoney does not force trailing zeros, formatNumber with forcePrecision
+--- does).
+local function axisMoney(value)
+    local n
+    if g_i18n ~= nil and type(g_i18n.formatNumber) == "function" then
+        local ok, s = pcall(g_i18n.formatNumber, g_i18n, value, 2, true)
+        if ok and type(s) == "string" then n = s end
+    end
+    if n == nil then n = string.format("%.2f", value or 0) end
+    return graphCurrency() .. n
+end
+
+--- Display title for a fill type index, or nil when it cannot be resolved.
+function MDMMarketScreenGraph._fillTypeTitle(fillTypeIndex)
+    if fillTypeIndex == nil or g_fillTypeManager == nil then return nil end
+    local ft = g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
+    if ft == nil then return nil end
+    return ft.title or ft.name
+end
+
+--- Is this index priced per head? Mirrors MarketScreen:_isLivestock so the graph
+--- and the table never disagree about the unit.
+function MDMMarketScreenGraph._isLivestock(fillTypeIndex)
+    local sys = g_currentMission ~= nil and g_currentMission.animalSystem or nil
+    if sys == nil or type(sys.getSubTypeByFillTypeIndex) ~= "function" then
+        return false
+    end
+    local ok, subType = pcall(sys.getSubTypeByFillTypeIndex, sys, fillTypeIndex)
+    return ok and subType ~= nil
+end
+
+---@param series number[] plotted values (per-litre engine numbers)
+---@param ctx table|nil { label, perHead, points, source }
+function MDMMarketScreenGraph._drawLineChart(series, gx, gy, gw, gh, ctx)
     local n = #series
     if n < 2 then return end
+    ctx = ctx or {}
+
+    -- Reserve a strip at the top for the series label and one at the bottom for
+    -- the x-axis window, so neither can overlap the plotted line.
+    local titleH = gh * 0.11
+    local axisH  = gh * 0.09
+    local fullGy, fullGh = gy, gh
+    gy = gy + axisH
+    gh = math.max(gh - titleH - axisH, 0.001)
 
     -- Find min/max
     local minP = math.huge
@@ -307,9 +384,13 @@ function MDMMarketScreenGraph._drawLineChart(series, gx, gy, gw, gh)
         setTextAlignment(RenderText.ALIGN_RIGHT)
 
         local labelSize = math.max(gh * 0.020, 0.003)
-        local labelStr = string.format("$%.0f", price * 1000)
-        -- Rotate only when price integer part has 5+ digits (price*1000 >= 10000)
-        if price * 1000 >= 10000 then
+        -- BUILD 15:39 (PB-07): same unit and same 2dp as the table. Livestock is
+        -- per head, so it is NOT multiplied by 1000 - that multiplication on an
+        -- animal row is what produced the nonsense figures Brian reported.
+        local shown = ctx.perHead and price or (price * 1000)
+        local labelStr = axisMoney(shown)
+        -- Rotate only when the integer part gets long enough to collide.
+        if shown >= 10000 then
             local labelX = gx - 0.005
             setTextRotation(math.rad(30), labelX, ly)
             renderText(labelX, ly, labelSize, labelStr)
@@ -352,4 +433,50 @@ function MDMMarketScreenGraph._drawLineChart(series, gx, gy, gw, gh)
         _drawFilledCircle(points[i].x, points[i].y, dotR,
                         COLOR_DOT[1], COLOR_DOT[2], COLOR_DOT[3], COLOR_DOT[4])
     end
+
+    -- ── BUILD 15:39 (PB-07): the frame that makes the line readable ──────────
+    setTextColor(COLOR_LABEL[1], COLOR_LABEL[2], COLOR_LABEL[3], COLOR_LABEL[4])
+    setTextRotation(0, 0, 0)
+
+    -- Series label. With one series this IS the legend: it names exactly what
+    -- the line is and in which unit, which is what a legend is for.
+    local titleSize = math.max(fullGh * 0.055, 0.010)
+    local label = ctx.label
+    if label == nil or label == "" then
+        local fb = MDMUtil and MDMUtil.getModText("mdm_screen_price_trend")
+        label = (type(fb) == "string" and fb ~= "") and fb or "Price trend"
+    end
+    local unit
+    if ctx.perHead then
+        unit = MDMUtil and MDMUtil.getModText("mdm_screen_per_head")
+        if type(unit) ~= "string" or unit == "" then unit = "/ head" end
+    else
+        unit = MDMUtil and MDMUtil.getModText("mdm_screen_per_1000l")
+        if type(unit) ~= "string" or unit == "" then unit = "/ 1,000L" end
+    end
+    setTextBold(true)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    renderText(gx, fullGy + fullGh - titleH * 0.85,
+               titleSize, string.format("%s  (%s)", label, unit))
+    setTextBold(false)
+
+    -- X-axis window. Described from the samples actually plotted, never from an
+    -- invented date range: n points, oldest on the left, newest on the right.
+    local axisSize = math.max(fullGh * 0.042, 0.008)
+    local axisY    = fullGy + axisH * 0.15
+    local oldest = MDMUtil and MDMUtil.getModText("mdm_screen_graph_oldest")
+    if type(oldest) ~= "string" or oldest == "" then oldest = "oldest" end
+    local newest = MDMUtil and MDMUtil.getModText("mdm_screen_graph_newest")
+    if type(newest) ~= "string" or newest == "" then newest = "now" end
+
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    renderText(gx, axisY, axisSize, oldest)
+    setTextAlignment(RenderText.ALIGN_RIGHT)
+    renderText(gx + gw, axisY, axisSize, newest)
+    setTextAlignment(RenderText.ALIGN_CENTER)
+    local span = MDMUtil and MDMUtil.getModText("mdm_screen_graph_span")
+    if type(span) ~= "string" or span == "" then span = "%d samples" end
+    local okSpan, spanTxt = pcall(string.format, span, n)
+    renderText(gx + gw * 0.5, axisY, axisSize, okSpan and spanTxt or tostring(n))
+    setTextAlignment(RenderText.ALIGN_LEFT)
 end

--- a/src/gui/MdPriceFormat.lua
+++ b/src/gui/MdPriceFormat.lua
@@ -1,0 +1,180 @@
+-- =========================================================
+-- FS25_MarketDynamics - MdPriceFormat
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- BUILD 23:47 - one place that decides how a market price is written.
+--
+-- Three surfaces used to answer this question separately and disagreed. The
+-- Esc Prices table printed the raw per-litre number with no decimals and no
+-- unit, the full Market table printed the same number times a thousand with a
+-- litre suffix, and the Esc selected-crop line printed the raw number again.
+-- Same price, three readings, and the animal rows on the full Market table read
+-- like a tanker price for a single cow.
+--
+-- Engine numbers stay per litre. MarketEngine.current, the history samples,
+-- PriceHook and contract settlement are untouched. The thousand is a display
+-- multiply and it lives here, once.
+--
+-- Animals are the exception, and the test is an existing AnimalSystem lookup
+-- rather than an invented fill-type flag: a fill type that names an animal
+-- subtype is one animal per unit, so multiplying it by a thousand would be
+-- nonsense. Milk, wool, eggs, manure and feed are subtype OUTPUTS, not cargo
+-- identities, so the lookup returns nil for them and they stay on the litre
+-- path with no list to maintain.
+-- =========================================================
+
+MDMPriceFormat = MDMPriceFormat or {}
+
+-- Verbatim the suffix the full Market table already shipped, so the Esc table
+-- and the full Market table print the same string and not two dialects of it.
+MDMPriceFormat.LITRE_SUFFIX = " / 1,000L"
+MDMPriceFormat.LITRE_FACTOR = 1000
+MDMPriceFormat.PRECISION = 2
+
+--- True when this fill type is an animal cargo identity rather than a bulk good.
+function MDMPriceFormat.isAnimalCargo(fillTypeIndex)
+    if fillTypeIndex == nil then
+        return false
+    end
+
+    local animalSystem = nil
+    if g_currentMission ~= nil then
+        animalSystem = g_currentMission.animalSystem
+    end
+
+    return animalSystem ~= nil
+        and type(animalSystem.getSubTypeByFillTypeIndex) == "function"
+        and animalSystem:getSubTypeByFillTypeIndex(fillTypeIndex) ~= nil
+end
+
+-- Only reached when there is no I18N object at all, which means there is no
+-- locale to respect in the first place.
+MDMPriceFormat.FALLBACK_SEPARATOR = "."
+
+--- Currency with both decimals always printed, including a trailing 00.
+---
+--- BUILD 00:16, Vera F2. The first version of this asked formatNumber for the
+--- digits with forcePrecision set, on the understanding that the flag forces
+--- them. It does not. formatNumber rounds and then calls tostring, and tostring
+--- of a whole number writes no decimal point at all, so the decimal branch
+--- never runs and the flag is never consulted: 512 prints as "512". Even when
+--- there IS a fraction the flag only keeps what tostring already wrote, so
+--- 512.5 prints as one decimal place and never as two. There is no I18N helper
+--- that pads, and formatMoney is worse because it does not pass the flag at
+--- all. So the digits are built here.
+---
+--- The one engine call left is grouping. formatNumber is handed an integer and
+--- precision 0, purely so the thousands separator is the locale's own, and it
+--- is structurally incapable of adding decimals to an integer.
+function MDMPriceFormat.money(value)
+    if value == nil then
+        return "-"
+    end
+
+    local rounded = value
+    if MathUtil ~= nil and type(MathUtil.round) == "function" then
+        rounded = MathUtil.round(value, MDMPriceFormat.PRECISION)
+    end
+
+    -- Split toward zero with the sign carried separately. math.floor on a
+    -- negative rounds away from zero, which would turn -0.50 into -1 and 50.
+    local negative = rounded < 0
+    local magnitude = negative and -rounded or rounded
+    local whole = math.floor(magnitude)
+    local frac = math.floor((magnitude - whole) * 100 + 0.5)
+    if frac >= 100 then
+        -- A magnitude that rounds up at the hundredths, 512.999 and the like.
+        whole = whole + 1
+        frac = frac - 100
+    end
+
+    local wholeStr = tostring(whole)
+    local separator = MDMPriceFormat.FALLBACK_SEPARATOR
+    local symbol = ""
+
+    if g_i18n ~= nil then
+        if type(g_i18n.formatNumber) == "function" then
+            wholeStr = g_i18n:formatNumber(whole, 0)
+        end
+        -- The locale's own mark, never a hardcoded dot. German groups with "."
+        -- and separates with ",", so a dot appended to a grouped integer would
+        -- read 1.234.00 and mean nothing.
+        if type(g_i18n.decimalSeparator) == "string" and g_i18n.decimalSeparator ~= "" then
+            separator = g_i18n.decimalSeparator
+        end
+        if type(g_i18n.getCurrencySymbol) == "function" then
+            symbol = g_i18n:getCurrencySymbol(true) or ""
+        end
+    end
+
+    -- %02d pads the fraction to two digits and writes no separator of its own,
+    -- which is the same shape the vanilla fill-level readouts use.
+    local out = symbol .. wholeStr .. separator .. string.format("%02d", frac)
+    if negative then
+        out = "-" .. out
+    end
+
+    return out
+end
+
+--- The number a price axis should plot for this fill type. Animal cargo is not
+--- multiplied, everything else is, and the caller uses this for the label and
+--- for any threshold that keys off the displayed magnitude so the two cannot
+--- drift apart.
+function MDMPriceFormat.displayValue(fillTypeIndex, current)
+    if current == nil then
+        return nil
+    end
+
+    if MDMPriceFormat.isAnimalCargo(fillTypeIndex) then
+        return current
+    end
+
+    return current * MDMPriceFormat.LITRE_FACTOR
+end
+
+--- The full string a price cell should show.
+function MDMPriceFormat.price(fillTypeIndex, current)
+    if current == nil then
+        return "-"
+    end
+
+    if MDMPriceFormat.isAnimalCargo(fillTypeIndex) then
+        return MDMPriceFormat.money(current)
+    end
+
+    return MDMPriceFormat.money(current * MDMPriceFormat.LITRE_FACTOR) .. MDMPriceFormat.LITRE_SUFFIX
+end
+
+-- =========================================================
+-- BUILD 14:04 (Vera FAIL SUBMIT 10:16, George TASK 10:53 GO): publish on load.
+--
+-- The class table above is a global in THIS mod's environment only. The shared Esc host
+-- executes inside whichever mod won the door race, and Vera's live gate showed that of the
+-- host's cross-env belts only the mission handle actually resolves on the live engine
+-- (via=mission) - g_modEnvironments carries nothing there and getfenv(0) is the per-mod
+-- sandbox. So the formatter announces itself instead of waiting to be found:
+--   _G            - resolves through the sandbox chain; where the engine backs it with the
+--                   real global table this write is visible to every mod's _G probe, and
+--                   where the sandbox loops _G onto itself it is a harmless self-write.
+--                   pcall-guarded because a locked global table must not kill the source.
+--   getfenv(0)    - the sandbox root, same target mdPublishHandles already uses.
+--   mission       - the proven live channel. Nil at source time on a cold boot, which is
+--                   why MdRfPdaGuest.mdPublishHandles re-publishes this class on every
+--                   register attempt: no Prices row can paint before a register succeeded.
+-- =========================================================
+pcall(function()
+    if _G ~= nil then
+        _G.MDMPriceFormat = MDMPriceFormat
+    end
+end)
+do
+    local okEnv, root = pcall(getfenv, 0)
+    if okEnv and type(root) == "table" then
+        root.MDMPriceFormat = MDMPriceFormat
+    end
+    if g_currentMission ~= nil then
+        g_currentMission.MDMPriceFormat = MDMPriceFormat
+    end
+end

--- a/src/gui/MdRfPdaGuest.lua
+++ b/src/gui/MdRfPdaGuest.lua
@@ -505,7 +505,16 @@ local function paintDetail(container)
     setText(cropEl, fillTypeTitle(ft))
     setTextColor(cropEl, unpack(COLOR_LIME))
 
-    local priceLine = string.format("%s  ·  %s", formatMoney(price), formatSignedPct(pct))
+    -- PB-02. The selected-crop line reads the same as the row it came from. Before this it
+    -- printed the raw per-litre engine number through formatMoney, which is the same zero-
+    -- decimal, no-unit reading that made the table say "£0". MDMPriceFormat is the one place
+    -- that decides how a market price is written; the guard keeps the old string if the
+    -- helper file ever fails to load rather than blanking the line.
+    local priceText = formatMoney(price)
+    if MDMPriceFormat ~= nil then
+        priceText = MDMPriceFormat.price(ft, price)
+    end
+    local priceLine = string.format("%s  ·  %s", priceText, formatSignedPct(pct))
     setText(priceEl, priceLine)
     if pct > 0.5 then
         setTextColor(priceEl, unpack(COLOR_UP))
@@ -1111,11 +1120,24 @@ local function mdPublishHandles()
         if MDMMarketScreenGraph ~= nil then
             root["MDMMarketScreenGraph"] = MDMMarketScreenGraph
         end
+        -- BUILD 14:04 (Vera FAIL SUBMIT 10:16, George TASK 10:53): MDMPriceFormat joins the
+        -- publish list. It was the one cross-env class the host needed that was NOT here,
+        -- so on a Dairy-hosted door every mdResolve belt missed it live (Vera's gate:
+        -- via=mission is the belt that works, and this list is what feeds that belt) and
+        -- the Prices rows fell to the rounded fallback. Guarded like the graph: the row
+        -- cells only paint under a registered guest, and every register attempt runs this,
+        -- so a painted row implies a published formatter.
+        if MDMPriceFormat ~= nil then
+            root["MDMPriceFormat"] = MDMPriceFormat
+        end
     end
     if g_currentMission ~= nil then
         g_currentMission.MdRfPdaGuest = MdRfPdaGuest
         if MDMMarketScreenGraph ~= nil then
             g_currentMission.MDMMarketScreenGraph = MDMMarketScreenGraph
+        end
+        if MDMPriceFormat ~= nil then
+            g_currentMission.MDMPriceFormat = MDMPriceFormat
         end
     end
 end

--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -256,6 +256,11 @@ function RfEscModules:registerModule(def)
         -- companions that predate this.
         selectCommodityIndex = def.selectCommodityIndex,
         onLightTick = def.onLightTick,
+        -- Sixth instance, BUILD 14:04 (Brian TEST 10:29): NPC Favor registered onPageStep
+        -- for the shared row pager on BUILD 09:19 and this whitelist ate it, so the live
+        -- MORE (1/2) button forwarded a step to nil and the roster never turned the page.
+        -- The register-time warning below did name it, in a log nobody read back.
+        onPageStep = def.onPageStep,
     }
     -- BUILD 23:51: this whitelist has now silently eaten a handler four times, so stop
     -- letting it do that quietly. Anything a caller passed that is not carried above gets

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -1033,13 +1033,56 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
         return
     end
 
-    sel.disableButtonsOnSingleText = false
-    sel.hideLeftRightButtons = false
-    if sel.setCanChangeState then
-        sel:setCanChangeState(true)
+    -- BUILD 17:50 (PB-06). The item count decides everything below this line.
+    --
+    -- Before 17:50 this helper forced the arrows enabled and full lime unconditionally,
+    -- which was the fault it fixed: with a single entry the arrow cannot change state, so
+    -- the player saw a bright, clickable-looking arrow that could never act.
+    --
+    -- 17:50 leaned on disableButtonsOnSingleText to express that. BUILD 20:39 takes it back
+    -- off (see the note below the empty-list guard) and drives disabled from here alone.
+    -- Line references throughout are
+    -- .local/ref/FS25-lua-scripting/elements/MultiTextOptionElement.lua unless named
+    -- otherwise. Nothing here is guessed.
+    local texts = sel.texts or {}
+
+    -- BUILD 20:39. An empty text list means "not seeded yet", not "one page", and the two
+    -- must not be treated the same. Every caller below runs this helper both BEFORE and
+    -- AFTER the texts are set, so the early call used to latch the pager disabled from a
+    -- count that was about to change - and if the seeding path then failed or threw, the
+    -- pager stayed disabled for the rest of the session while the arrows below still got
+    -- painted. That is one of the three ways George's TASK 20:38 lime-but-dead read is
+    -- reachable. With no texts there is nothing to page through, so write nothing and let
+    -- the seeded call decide.
+    if #texts == 0 then
+        return
     end
+    local multi = #texts > 1
+
+    -- BUILD 20:39: disableButtonsOnSingleText stays FALSE (Sam feel lock DESIGN 20:00,
+    -- re-stated in BUILD 20:39; the XML declares false on every MTO in this page).
+    -- 17:50 read it as a free engine helper, but it is not free: with it true the engine
+    -- writes setDisabled(#texts <= 1) from inside updateContentElement (:831-833), and
+    -- updateContentElement runs on every setTexts, setState and arrow click. That is a
+    -- second writer on the one flag that decides whether the pager takes input at all,
+    -- firing on the same frame as our own write - "state reset in the same frame", the
+    -- third cause George named. With it false this function is the only writer.
+    -- The single-page focus guard 17:50 wanted from it is not lost: canReceiveFocus (:774)
+    -- also returns false on a disabled element, and one page still sets disabled below.
+    sel.disableButtonsOnSingleText = false
+    sel.hideLeftRightButtons = false   -- never remove the control, only dim it
+    if sel.setCanChangeState then
+        sel:setCanChangeState(multi)
+    end
+    -- This is the gate that decides whether a click ever reaches the arrows. A disabled
+    -- MTO swallows the whole mouse event before it can descend to its buttons:
+    -- MultiTextOptionElement:mouseEvent wraps its entire body in getIsActive() (:434) and
+    -- GuiElement:getIsActive is "not disabled and visible" (GuiElement.lua:1338-1340).
+    -- The GuiOverlay.setColor tint further down does NOT go through that gate, so a
+    -- disabled pager still paints lime - which is exactly the reported defect: lime arrows,
+    -- dead clicks. Multi-page must therefore end this call with disabled == false.
     if sel.setDisabled then
-        sel:setDisabled(false)
+        sel:setDisabled(not multi)
     end
 
     -- Extract: GuiUtils.getNormalizedScreenValues(values, default) - values = "Wpx Hpx" or array; returns table.
@@ -1053,11 +1096,22 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
     end
 
     -- ButtonElement extends TextElement (not Bitmap); tint via GuiOverlay on .overlay.
-    local r, g, b, a = 0.549, 0.776, 0.247, 1
+    --
+    -- Enabled keeps George's lime. Disabled goes to Samantha's neutral 45% rather than a faded
+    -- lime, so "cannot act" reads as absence of colour instead of a dimmed affordance. The
+    -- brief writes the enabled state as {1,1,1,1}, which would drop the lime this file already
+    -- carries; that is not what PB-06 is about, so the lime stays and the reading is flagged
+    -- in the reply rather than decided silently.
+    local r, g, b, a
+    if multi then
+        r, g, b, a = 0.549, 0.776, 0.247, 1
+    else
+        r, g, b, a = 1, 1, 1, 0.45
+    end
     for _, btn in ipairs({ sel.leftButtonElement, sel.rightButtonElement }) do
         if btn ~= nil then
             if btn.setVisible then btn:setVisible(true) end
-            if btn.setDisabled then btn:setDisabled(false) end
+            if btn.setDisabled then btn:setDisabled(not multi) end
             -- Size THEN lime (George Plan A). Absolute target - do not ratio current size.
             if type(btn.setSize) == "function" and tw ~= nil and th ~= nil then
                 btn:setSize(tw, th)
@@ -1073,8 +1127,19 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
 end
 
 --- Keep Map circle arrows enabled + lime on first open (not near-black grey).
+--- BUILD 20:39: also the wrap lock for the left-pane pager. Wrap is engine-native and on
+--- by default (MultiTextOptionElement.lua:55) - onRightButtonClicked rolls #texts -> 1 and
+--- onLeftButtonClicked rolls 1 -> #texts (:670-679 / :721-730) - but XML #wrap and profile
+--- "wrap" can both turn it off (:111 / :141), and with it off the last page clamps and the
+--- arrow reads dead at exactly one end. The ask is explicit that both ends wrap, so state
+--- it rather than inherit it. Set here on the pager only: _ensureMtoArrowsVisible is shared
+--- with the WC wage / About / subnav MTOs, and their wrap is not this token's business.
 function RfPdaMenuPage:_ensureSelectorArrowsVisible()
-    self:_ensureMtoArrowsVisible(self.rfPanelSelector)
+    local sel = self.rfPanelSelector
+    if sel ~= nil then
+        sel.wrap = true
+    end
+    self:_ensureMtoArrowsVisible(sel)
 end
 
 --- Stable id list fingerprint for quiet SmoothList reload decisions.
@@ -1114,7 +1179,10 @@ function RfPdaMenuPage:refreshPanelSelector(forceRebuildDots)
             activeIndex = 1
         end
 
-        self:_ensureSelectorArrowsVisible()
+        -- BUILD 20:39: the pre-setTexts ensure call that used to sit here is gone. It fed
+        -- _ensureMtoArrowsVisible the PREVIOUS text count - on first open an empty one - so
+        -- it decided the pager's disabled state from a number that the next line was about
+        -- to replace. The post-setState call below is the one that matters and it stays.
         -- setTexts can re-apply profile single-text disable; always follow with force-enable.
         self.rfPanelSelector:setTexts(texts)
         if self.rfPanelSelector.setState then
@@ -1270,14 +1338,43 @@ function RfPdaMenuPage:_applySelectorState()
 
     local state = self.rfPanelSelector:getState()
     local panel = self._panelCache[state]
-    if panel == nil then return end
+    if panel == nil then
+        -- BUILD 20:39: this is the second half of the defect. The arrow has already moved
+        -- the label and the dots by the time we get here (the engine advances state, then
+        -- raises this callback), so returning empty-handed leaves the page NAME on one
+        -- module and the page CONTENT on another - the "content does not move" read. A
+        -- cache one module older than the MTO texts is enough to hit it. Re-read the
+        -- registry once before giving up.
+        local panels = (type(host.getPanels) == "function") and host:getPanels() or nil
+        if panels ~= nil then
+            self._panelCache = panels
+            panel = panels[state]
+        end
+    end
+    if panel == nil then
+        -- Still nothing at this index: put the pager back on the page that is actually
+        -- showing. An honest snap-back beats a label pointing at a page that never loaded.
+        self:_restoreBrandToActivePanel()
+        return
+    end
 
     if host.activeModuleId ~= panel.id then
         if not self:_allowModuleSelect(panel.id) then
+            -- Refused by the dual-fire debounce. The MTO state has still moved, so snap it
+            -- back or label, dots and content stay disagreeing until the next full refresh.
+            self:_restoreBrandToActivePanel()
             return
         end
         -- Host notify refreshes selector + content (quiet lists).
-        host:selectPanel(panel.id)
+        local switched = host:selectPanel(panel.id)
+        if switched == false then
+            -- Registry refused (module gone or isAvailable false): no notify fires, so
+            -- nothing downstream would ever correct the advanced label. Snap it back.
+            SoilLogger.warning("RfPdaMenuPage: selectPanel %s refused, restoring pager state",
+                tostring(panel.id))
+            self:_restoreBrandToActivePanel()
+            return
+        end
         SoilLogger.info("RfPdaMenuPage: selectPanel %s (arrow/selector)", tostring(panel.id))
     else
         self:refreshContent(false)

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -16,17 +16,29 @@
 local MOD_DIR = g_currentModDirectory
 local MOD_NAME = g_currentModName
 
--- Soft log when sourced from WC/CS joiners (SoilLogger may be absent).
+-- Soft log when sourced from a non-Soil joiner (SoilLogger may be absent).
+-- BUILD 17:08: the stub's signature must match Soil's real logger, which is DOT-called
+-- with the format first (src/utils/Logger.lua: function SoilLogger.info(msg, ...)), and
+-- every call in this file is dot-style. The old stub took (_, fmt, ...) as if colon-called,
+-- so on every non-Soil-hosted door the message landed in the discarded first slot and the
+-- log printed only the leftover arguments - or nothing at all. That is why the host's
+-- [RfEsc] lines have never appeared in a Dairy-door log, and it would have eaten the
+-- selector diagnostics this build ships. pcall on the format so a stray % in a runtime
+-- value can never turn a log line into the only traceback on the page.
 if SoilLogger == nil then
+    local function stubLine(fmt, ...)
+        local ok, text = pcall(string.format, fmt or "", ...)
+        return "[RfEsc] " .. (ok and text or tostring(fmt))
+    end
     SoilLogger = {
-        info = function(_, fmt, ...)
-            if Logging and Logging.info then Logging.info("[RfEsc] " .. string.format(fmt or "", ...)) end
+        info = function(fmt, ...)
+            if Logging and Logging.info then Logging.info(stubLine(fmt, ...)) end
         end,
-        warning = function(_, fmt, ...)
-            if Logging and Logging.warning then Logging.warning("[RfEsc] " .. string.format(fmt or "", ...)) end
+        warning = function(fmt, ...)
+            if Logging and Logging.warning then Logging.warning(stubLine(fmt, ...)) end
         end,
-        error = function(_, fmt, ...)
-            if Logging and Logging.error then Logging.error("[RfEsc] " .. string.format(fmt or "", ...)) end
+        error = function(fmt, ...)
+            if Logging and Logging.error then Logging.error(stubLine(fmt, ...)) end
         end,
     }
 end
@@ -198,7 +210,9 @@ local function mdResolve(bare, name)
             MdRfPdaGuest = "FS25_MarketDynamics",
             MDMMarketScreenGraph = "FS25_MarketDynamics",
             MDMMarketScreen = "FS25_MarketDynamics",
+            MDMPriceFormat = "FS25_MarketDynamics",
             CsRfPdaGuest = "FS25_SeasonalCropStress",
+            NpcRfPdaGuest = "FS25_NPCFavor",
         }
         local env = g_modEnvironments[OWNER[name] or "FS25_MarketDynamics"]
         if env ~= nil and env[name] ~= nil then
@@ -212,16 +226,69 @@ local function mdResolve(bare, name)
             end
         end
     end
-    -- 4. real global table: MarketDynamics publishes here from BUILD 11:43.
+    -- 4. _G. BUILD 14:04 (George TASK 10:53): Vera's live gate read via=mission, which
+    --    means belts 2 and 3 miss on the live engine (g_modEnvironments carries nothing
+    --    there) and getfenv(0) is the per-mod sandbox, not a shared root. _G read from mod
+    --    code resolves through the sandbox chain, so when the engine backs it with the real
+    --    global table this belt sees a publisher's _G write; when the sandbox loops _G onto
+    --    itself it degenerates to the bare lookup and costs one table index.
+    if type(_G) == "table" and _G[name] ~= nil then
+        return _G[name]
+    end
+    -- 5. sandbox root: MarketDynamics publishes here from BUILD 11:43.
     local okEnv, root = pcall(getfenv, 0)
     if okEnv and type(root) == "table" and root[name] ~= nil then
         return root[name]
     end
-    -- 5. mission handle, same publish.
+    -- 6. mission handle, same publish. The one belt Vera's live gate has actually seen
+    --    resolve on a non-MD door (via=mission), so it must stay last-resort-but-present.
     if g_currentMission ~= nil and g_currentMission[name] ~= nil then
         return g_currentMission[name]
     end
     return nil
+end
+
+--- BUILD 14:04 fence for _populateMdCommodityRow: 2dp currency when MDMPriceFormat cannot
+--- be resolved at all. George's constraint on the failed probe is "degrades to 2dp path -
+--- never formatMoney(..., 0)". This is the Vera-F2 pad rule in miniature (formatNumber and
+--- formatMoney both round-then-tostring, so neither ever pads a whole number to .00): split
+--- the digits by hand, let formatNumber group the integer half only, take the locale's own
+--- decimal mark. No x1000, no litre suffix, no animal test - that display policy lives in
+--- MDMPriceFormat and duplicating it here would put two dialects back on screen. This fence
+--- should be unreachable: the Prices rows only paint under a registered MD guest, and
+--- registration publishes MDMPriceFormat to the mission handle every attempt.
+local function mdMoney2(value)
+    local rounded = value
+    if MathUtil ~= nil and type(MathUtil.round) == "function" then
+        rounded = MathUtil.round(value, 2)
+    end
+    local negative = rounded < 0
+    local magnitude = negative and -rounded or rounded
+    local whole = math.floor(magnitude)
+    local frac = math.floor((magnitude - whole) * 100 + 0.5)
+    if frac >= 100 then
+        whole = whole + 1
+        frac = frac - 100
+    end
+    local wholeStr = tostring(whole)
+    local separator = "."
+    local symbol = ""
+    if g_i18n ~= nil then
+        if type(g_i18n.formatNumber) == "function" then
+            wholeStr = g_i18n:formatNumber(whole, 0)
+        end
+        if type(g_i18n.decimalSeparator) == "string" and g_i18n.decimalSeparator ~= "" then
+            separator = g_i18n.decimalSeparator
+        end
+        if type(g_i18n.getCurrencySymbol) == "function" then
+            symbol = g_i18n:getCurrencySymbol(true) or ""
+        end
+    end
+    local out = symbol .. wholeStr .. separator .. string.format("%02d", frac)
+    if negative then
+        out = "-" .. out
+    end
+    return out
 end
 
 local function tr(key, fallback)
@@ -1283,6 +1350,13 @@ function RfPdaMenuPage:_rebuildDots(count)
 end
 
 function RfPdaMenuPage:onClickRfPanelSelector()
+    -- BUILD 17:08 diagnostic, one line per real selector input (forceEvent is false on
+    -- every internal setState in this file, so this callback only fires for the player).
+    -- If a live test still shows dead arrows AND this line never appears in the log, the
+    -- click is being consumed ABOVE this page (menu-level), which the in-page shield in
+    -- mouseEvent cannot reach - that finding goes to George, not to more host code.
+    SoilLogger.info("RfPdaMenuPage: selector input received, state=%s",
+        tostring(self.rfPanelSelector ~= nil and self.rfPanelSelector:getState() or "?"))
     self:_ensureSelectorArrowsVisible()
     self:_applySelectorState()
 end
@@ -1551,6 +1625,17 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         end
     end
     setVis(self.rfHostTableRegion, isCs)
+    -- BUILD 09:19 (PB-07): the shared row pager is OFF by default, every refresh, for every
+    -- module. Only a guest that implements onPageStep turns it back on, from inside its own
+    -- onShow, which runs after this. That ordering is what stops the pager following the
+    -- player from NPC Favor onto Income or Dairy - those guests do not know the buttons
+    -- exist and would never have hidden them.
+    for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext" }) do
+        local btn = self:getDescendantById(id)
+        if btn ~= nil and type(btn.setVisible) == "function" then
+            btn:setVisible(false)
+        end
+    end
     -- Action bar rides the CS module only; the guest decides the two buttons.
     setVis(self.csActionBar, isCs)
     if not isCs then
@@ -2336,6 +2421,136 @@ function RfPdaMenuPage:onClickHelpCs()
     end
 end
 
+-- ---------------------------------------------------------------------------
+-- BUILD 09:19 (PB-07): shared Table-mode row pager.
+--
+-- rfFwTableBlock is a STATIC eight-row table (rfFwRow1..rfFwRow8) - not a SmoothList - and
+-- four guests paint into it: Income, Dairy, NPC Favor and Fertilizer Depot. When a guest has
+-- more rows than eight it prints "showing 8 of 11" into rfFwMore and the other three rows
+-- were unreachable: no scrollbar, no page control, no route of any kind. Sam's law is that a
+-- list which prints a range must be navigable to the end of that range.
+--
+-- This is a PAGER and deliberately not a SmoothList. George's standing hang lesson is that a
+-- SmoothList nested under the Map-style Bitmap shell in this page can hang the frame, and the
+-- existing csConsultPanel carries the same NO-GO ("George NO-GO on TextElement.new rebuild,
+-- dialog XML nest, or SmoothList"). Two Buttons plus a window offset held by the guest costs
+-- no new list machinery and cannot re-enter the layout.
+--
+-- The host owns only the click. It knows nothing about roster size, page count or labels -
+-- it forwards a step to whichever guest is active and then repaints. A guest that does not
+-- implement onPageStep is simply not pageable and the buttons stay hidden, which is why the
+-- other three Table guests need no change to keep working exactly as before.
+-- ---------------------------------------------------------------------------
+
+--- Forward one page step to the active guest, then repaint the page it just moved.
+---@param delta number -1 for previous page, +1 for next
+---@return boolean moved true when the window moved and a repaint ran
+function RfPdaMenuPage:_rfFwPageStep(delta)
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active == nil then
+        return false
+    end
+    local step = active.onPageStep
+    -- BUILD 14:04 (Brian TEST 10:29). This is why the live MORE was a painted no-op: the
+    -- guest registered onPageStep exactly as BUILD 09:19 described, and
+    -- RfEscModules:registerModule silently dropped it - the sixth handler that whitelist
+    -- has eaten (onOpenFullMarket, onOpenConsultant/Schedule/Help, onPivotRemote,
+    -- onLightTick, onMoverChanged before it). The whitelist now carries onPageStep, and
+    -- this belt is the same shape as the 23:51 onLightTick belt directly below in
+    -- refreshContent: if the registry instance was created by a mod still running an old
+    -- RfEscModules copy, reach the guest class itself rather than shipping a dead button
+    -- again. npcFavor is the only pageable guest today, so the belt names it.
+    if type(step) ~= "function" and active.id == "npcFavor" then
+        local npcGuest = (type(mdResolve) == "function")
+                and mdResolve(NpcRfPdaGuest, "NpcRfPdaGuest") or NpcRfPdaGuest
+        if npcGuest ~= nil and type(npcGuest.onPageStep) == "function" then
+            step = npcGuest.onPageStep
+        end
+    end
+    if type(step) ~= "function" then
+        return false
+    end
+    -- The guest owns the clamp/wrap: it is the only side that knows how many rows it has.
+    -- It returns true when the window actually moved, so a click at a hard end does not
+    -- trigger a pointless full repaint.
+    local ok, moved = pcall(step, delta)
+    if not ok then
+        SoilLogger.warning("RfPdaMenuPage: onPageStep failed on %s: %s",
+            tostring(active.id), tostring(moved))
+        return false
+    end
+    if moved == false then
+        return false
+    end
+    -- Soft refresh: same path the module pager uses, so the guest repaints its rows and its
+    -- own footer range without a full enter/rebuild.
+    self:refreshContent(false)
+    return true
+end
+
+function RfPdaMenuPage:onClickRfFwPagePrev()
+    self:_rfFwPageStep(-1)
+end
+
+function RfPdaMenuPage:onClickRfFwPageNext()
+    self:_rfFwPageStep(1)
+end
+
+--- BUILD 14:04 (PB-07): Space and ">" advance the row pager, per the brief's
+--- "click/Space/>" acceptance. keyEvent walks children first via the superclass
+--- (GuiElement.lua:772-784, children in reverse order, eventUsed carried), so a focused
+--- control that consumes the key - including the pager Button itself activating on Space -
+--- wins before this fires and nothing double-steps. Only an unclaimed press reaches the
+--- step, and only a step that actually moved marks the event used; on every page without a
+--- pageable guest _rfFwPageStep returns false immediately and the key passes through
+--- untouched. unicode 32 is Space, 62 is ">", taken from the event's own unicode so the
+--- layout that produced ">" does not matter.
+function RfPdaMenuPage:keyEvent(unicode, sym, modifier, isDown, eventUsed)
+    local used = RfPdaMenuPage:superClass().keyEvent(self, unicode, sym, modifier, isDown, eventUsed)
+    if not used and isDown == true and (unicode == 32 or unicode == 62) then
+        used = self:_rfFwPageStep(1) == true
+    end
+    return used
+end
+
+--- BUILD 17:08 (Brian TEST 16:53, George TASK 17:03 GO): click shield for the module
+--- selector. Brian measured both selector arrows hover-highlighting but never advancing,
+--- with no Lua traceback. The engine split that allows exactly that: ButtonElement paints
+--- its hover state regardless of eventUsed (ButtonElement.lua:450-459) but fires its click
+--- only "if not eventUsed" (:469-491), and FocusManager highlight on the MTO is likewise
+--- move-driven (MultiTextOptionElement.lua:465-469). So hover-alive-click-dead means the
+--- CLICK half of the event is being consumed before the selector's walk position - George's
+--- hit-steal read. Event order in this engine is reverse declaration order with no z-index,
+--- and Sam's lock forbids moving any geometry, so the fix is delivery order, not layout:
+--- the page offers every click that lands inside the selector's rect to the selector FIRST,
+--- then runs the normal child walk with the event marked used, so whichever sibling was
+--- eating the click can still clear its own pressed state but can no longer act on it.
+--- Moves are NOT pre-offered - hover behavior is untouched, and a second visit of the MTO
+--- during the normal walk with eventUsed=true only re-computes identical press flags
+--- (:441-446, not eventUsed-gated), so nothing double-fires and no wrapper element is
+--- introduced. Clicks outside the selector rect take the walk exactly as before, so the
+--- module list, FW pager and every guest control keep their ownership.
+function RfPdaMenuPage:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+    local used = eventUsed
+    local sel = self.rfPanelSelector
+    if not used and (isDown or isUp) and sel ~= nil
+        and sel.absPosition ~= nil and sel.absSize ~= nil
+        and type(sel.getIsActive) == "function" and sel:getIsActive()
+        and GuiUtils ~= nil and type(GuiUtils.checkOverlayOverlap) == "function"
+        and GuiUtils.checkOverlayOverlap(posX, posY,
+            sel.absPosition[1], sel.absPosition[2], sel.absSize[1], sel.absSize[2], nil) then
+        if sel:mouseEvent(posX, posY, isDown, isUp, button, false) then
+            used = true
+            if not self._selShieldLogged then
+                self._selShieldLogged = true
+                SoilLogger.info("RfPdaMenuPage: selector click shield delivered its first click")
+            end
+        end
+    end
+    return RfPdaMenuPage:superClass().mouseEvent(self, posX, posY, isDown, isUp, button, used) or used
+end
+
 function RfPdaMenuPage:_csPageSel()
     return self.csSubnavSelector
 end
@@ -2786,12 +3001,50 @@ function RfPdaMenuPage:_populateMdCommodityRow(index, cell)
         end
     end
     if nameEl then nameEl:setText(entry.title or "-") end
+    -- BUILD 09:19 (PB-02). This cell is the one Brian read as "£0" and "£1".
+    --
+    -- entry.price is the PER-LITRE engine number. formatMoney(price, 0, ...) rounded it to
+    -- whole currency units and printed no unit at all, so a live 0.00037/l commodity became
+    -- an actionable-looking "£0" and soybean at 0.85/l became "£1". Neither is a zero and
+    -- neither says what it is a price OF.
+    --
+    -- MDMPriceFormat is the single place that decides how a market price is written: the
+    -- x1000 display multiply for bulk goods, the forced two decimals built by hand (Vera F2:
+    -- neither formatMoney nor formatNumber forcePrecision actually pads .00), the locale
+    -- decimal mark, and the " / 1,000L" suffix that animal cargo does NOT get. The full
+    -- Market table and the Esc selected-crop line call the same helper, so all three
+    -- surfaces print one string and not three dialects of it.
+    --
+    -- The nil guard matters on this file specifically: this host is mirrored into all nine
+    -- doors and only the Market Dynamics zip ships MdPriceFormat.lua. On the other eight
+    -- doors MDMPriceFormat is nil UNLESS Market Dynamics is also loaded - and if it is not
+    -- loaded there is no Market page to paint anyway. The fallback keeps the old reading
+    -- instead of erroring.
+    --
+    -- BUILD 10:06, Vera FAIL F1. The bare global was doing less than that comment claimed.
+    -- It is nil not only when Market Dynamics is absent, but whenever Market Dynamics is not
+    -- the mod that WON the door race: FS25 gives every mod its own environment and this
+    -- mirrored file executes inside the host's, so on a Dairy-hosted or Income-hosted suite
+    -- the bare lookup misses a fully loaded MdPriceFormat.lua and the cell silently drops to
+    -- the formatMoney fallback - the exact "GBP 0" reading PB-02 was supposed to have fixed.
+    -- Same failure shape, same cause and same cure as MDMMarketScreenGraph on the Dairy door.
+    -- Resolved through mdResolve, which is that cure: bare first (free when Market Dynamics
+    -- hosts), then the named g_modEnvironments["FS25_MarketDynamics"] entry, then the
+    -- name-independent scan and the getfenv(0) / mission belts.
+    local priceFormat = (type(mdResolve) == "function")
+            and mdResolve(MDMPriceFormat, "MDMPriceFormat") or MDMPriceFormat
     local priceText = "-"
     if entry.price ~= nil then
-        if g_i18n and g_i18n.formatMoney then
-            priceText = g_i18n:formatMoney(entry.price, 0, true, true)
+        if priceFormat ~= nil and type(priceFormat.price) == "function" then
+            priceText = priceFormat.price(entry.fillTypeIndex, entry.price)
         else
-            priceText = string.format("%.0f", entry.price)
+            -- BUILD 14:04 (Vera FAIL on SUBMIT 10:16). The old branch here was
+            -- formatMoney(entry.price, 0, ...), which is the exact GBP 0 / GBP 1 reading
+            -- this cell has now shipped twice. George's constraint is verbatim "failed
+            -- probe degrades to 2dp path - never formatMoney(..., 0)", so the raw
+            -- per-litre number prints at two decimals or it does not print through
+            -- an engine rounder at all.
+            priceText = mdMoney2(entry.price)
         end
     end
     if priceEl then priceEl:setText(priceText) end

--- a/translations/add_pb07_keys.py
+++ b/translations/add_pb07_keys.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""BUILD 15:39 / PB-07 - price units and graph context strings.
+
+Every key here is read through MDMUtil.getModText, which rejects the engine's
+"Missing '<key>'" placeholder and falls back to the English literal in the Lua.
+So none of these are load-bearing the way PB-08's XML-referenced key is - but
+shipping them means 25 of 26 languages do not silently fall back to English on a
+player surface.
+
+  mdm_screen_per_head        unit suffix for livestock rows (priced per animal)
+  mdm_screen_per_1000l       unit suffix for litre rows
+  mdm_screen_price_trend     graph title when no commodity is selected
+  mdm_screen_graph_oldest    x-axis left end
+  mdm_screen_graph_newest    x-axis right end
+  mdm_screen_graph_span      x-axis centre, "%d samples" (keep the %d)
+  mdm_screen_graph_median    graph title for the all-commodities median series
+
+Files are decoded utf-8-sig and written back as plain UTF-8 with no BOM.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+ORDER = ("mdm_screen_per_head", "mdm_screen_per_1000l", "mdm_screen_price_trend",
+         "mdm_screen_graph_oldest", "mdm_screen_graph_newest",
+         "mdm_screen_graph_span", "mdm_screen_graph_median")
+
+EN = ["/ head", "/ 1,000L", "Price trend", "oldest", "now", "%d samples",
+      "All commodities (median)"]
+
+TEXTS = {
+    "de": ["/ Tier", "/ 1.000 l", "Preisverlauf", "älteste", "jetzt", "%d Messwerte", "Alle Waren (Median)"],
+    "fr": ["/ tête", "/ 1 000 L", "Tendance des prix", "plus ancien", "maintenant", "%d relevés", "Toutes les marchandises (médiane)"],
+    "es": ["/ cabeza", "/ 1.000 L", "Tendencia de precios", "más antiguo", "ahora", "%d muestras", "Todas las mercancías (mediana)"],
+    "ea": ["/ cabeza", "/ 1.000 L", "Tendencia de precios", "más antiguo", "ahora", "%d muestras", "Todas las mercancías (mediana)"],
+    "it": ["/ capo", "/ 1.000 L", "Andamento prezzi", "meno recente", "ora", "%d campioni", "Tutte le merci (mediana)"],
+    "nl": ["/ dier", "/ 1.000 L", "Prijsverloop", "oudste", "nu", "%d metingen", "Alle goederen (mediaan)"],
+    "pl": ["/ szt.", "/ 1000 l", "Trend cen", "najstarsze", "teraz", "%d próbek", "Wszystkie towary (mediana)"],
+    "pt": ["/ cabeça", "/ 1.000 L", "Tendência de preços", "mais antigo", "agora", "%d amostras", "Todas as mercadorias (mediana)"],
+    "br": ["/ cabeça", "/ 1.000 L", "Tendência de preços", "mais antigo", "agora", "%d amostras", "Todas as mercadorias (mediana)"],
+    "ru": ["/ голову", "/ 1 000 л", "Динамика цен", "ранее", "сейчас", "%d замеров", "Все товары (медиана)"],
+    "uk": ["/ голову", "/ 1 000 л", "Динаміка цін", "раніше", "зараз", "%d замірів", "Усі товари (медіана)"],
+    "cz": ["/ kus", "/ 1 000 l", "Vývoj cen", "nejstarší", "nyní", "%d vzorků", "Všechny komodity (medián)"],
+    "da": ["/ dyr", "/ 1.000 L", "Prisudvikling", "ældste", "nu", "%d målinger", "Alle varer (median)"],
+    "no": ["/ dyr", "/ 1 000 L", "Prisutvikling", "eldste", "nå", "%d målinger", "Alle varer (median)"],
+    "sv": ["/ djur", "/ 1 000 L", "Prisutveckling", "äldsta", "nu", "%d mätvärden", "Alla varor (median)"],
+    "fi": ["/ eläin", "/ 1 000 l", "Hintakehitys", "vanhin", "nyt", "%d näytettä", "Kaikki tuotteet (mediaani)"],
+    "hu": ["/ állat", "/ 1000 l", "Ártrend", "legrégebbi", "most", "%d minta", "Minden áru (medián)"],
+    "ro": ["/ cap", "/ 1.000 L", "Tendința prețurilor", "cel mai vechi", "acum", "%d probe", "Toate mărfurile (mediană)"],
+    "tr": ["/ baş", "/ 1.000 L", "Fiyat eğilimi", "en eski", "şimdi", "%d örnek", "Tüm ürünler (medyan)"],
+}
+
+
+def read(path):
+    return path.read_bytes().decode("utf-8-sig")
+
+
+def write(path, text):
+    path.write_bytes(text.encode("utf-8"))
+
+
+def esc(v):
+    return v.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def main():
+    files = sorted(HERE.glob("translation_*.xml"))
+    if not files:
+        print("no translation_*.xml found")
+        return 1
+
+    changed = 0
+    for path in files:
+        lang = path.stem.split("_", 1)[1]
+        body = read(path)
+        vals = TEXTS.get(lang, EN)
+
+        entries = []
+        for i, key in enumerate(ORDER):
+            if 'name="%s"' % key in body:
+                continue
+            entries.append('        <text name="%s" text="%s" />' % (key, esc(vals[i])))
+
+        if not entries:
+            continue
+        block = "\n".join(entries) + "\n"
+        new = re.sub(r"([ \t]*)</texts>", block + r"\1</texts>", body, count=1)
+        if new == body:
+            print("could not find </texts> in %s" % path.name)
+            return 1
+        write(path, new)
+        changed += 1
+
+    print("patched %d of %d translation file(s)" % (changed, len(files)))
+
+    bad = []
+    for path in files:
+        body = read(path)
+        for key in ORDER:
+            n = body.count('name="%s"' % key)
+            if n != 1:
+                bad.append("%s: %s x%d" % (path.name, key, n))
+        # The span string must keep its %d or string.format silently drops the count.
+        m = re.search(r'name="mdm_screen_graph_span" text="([^"]*)"', body)
+        if m and "%d" not in m.group(1):
+            bad.append("%s: graph_span lost its %%d" % path.name)
+    if bad:
+        print("VERIFY FAILED:")
+        for b in bad:
+            print("  " + b)
+        return 1
+    print("verified: all %d keys present exactly once in all %d files" % (len(ORDER), len(files)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/translations/add_pb08_keys.py
+++ b/translations/add_pb08_keys.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""BUILD 15:39 / PB-08 - player language in place of raw internal identifiers.
+
+Adds the keys the Event Settings dialog needs once the raw TRACKED FILL TYPES
+token list is replaced by plain tracked categories:
+
+  mdm_evt_tracked_label   section heading (was a hardcoded English literal in the
+                          XML, so this one is REQUIRED: $l10n_ renders
+                          "Missing '<key>'" when the key is absent)
+  mdm_cat_crops           category labels; the Lua guards these with hasText, so
+  mdm_cat_silage          they are additive and safe, but they are shipped in
+  mdm_cat_livestock       every language anyway rather than falling back to
+  mdm_cat_other           English on 25 of 26 surfaces
+
+Languages without a hand-written translation take English rather than a
+machine-mangled sentence. These are single nouns, so coverage is wide.
+
+Files are decoded utf-8-sig and written back as plain UTF-8 with no BOM.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+KEYS = ("mdm_evt_tracked_label", "mdm_cat_crops", "mdm_cat_silage",
+        "mdm_cat_livestock", "mdm_cat_other")
+
+EN = {
+    "mdm_evt_tracked_label": "Tracked market categories",
+    "mdm_cat_crops": "Crops",
+    "mdm_cat_silage": "Silage",
+    "mdm_cat_livestock": "Livestock",
+    "mdm_cat_other": "Other",
+}
+
+TEXTS = {
+    "de": ["Erfasste Marktkategorien", "Feldfrüchte", "Silage", "Tierhaltung", "Sonstige"],
+    "fr": ["Catégories de marché suivies", "Cultures", "Ensilage", "Élevage", "Autres"],
+    "es": ["Categorías de mercado seguidas", "Cultivos", "Ensilado", "Ganado", "Otros"],
+    "ea": ["Categorías de mercado seguidas", "Cultivos", "Ensilado", "Ganado", "Otros"],
+    "it": ["Categorie di mercato monitorate", "Colture", "Insilato", "Bestiame", "Altro"],
+    "nl": ["Gevolgde marktcategorieën", "Gewassen", "Kuilvoer", "Vee", "Overig"],
+    "pl": ["Śledzone kategorie rynku", "Uprawy", "Kiszonka", "Zwierzęta", "Inne"],
+    "pt": ["Categorias de mercado seguidas", "Culturas", "Silagem", "Gado", "Outros"],
+    "br": ["Categorias de mercado monitoradas", "Culturas", "Silagem", "Gado", "Outros"],
+    "ru": ["Отслеживаемые категории рынка", "Культуры", "Силос", "Скот", "Прочее"],
+    "uk": ["Відстежувані категорії ринку", "Культури", "Силос", "Худоба", "Інше"],
+    "cz": ["Sledované kategorie trhu", "Plodiny", "Siláž", "Dobytek", "Ostatní"],
+    "da": ["Fulgte markedskategorier", "Afgrøder", "Ensilage", "Husdyr", "Andet"],
+    "no": ["Fulgte markedskategorier", "Vekster", "Silo", "Husdyr", "Annet"],
+    "sv": ["Följda marknadskategorier", "Grödor", "Ensilage", "Boskap", "Övrigt"],
+    "fi": ["Seuratut markkinaluokat", "Viljelykasvit", "Säilörehu", "Karja", "Muut"],
+    "hu": ["Követett piaci kategóriák", "Növények", "Szilázs", "Állatok", "Egyéb"],
+    "ro": ["Categorii de piață urmărite", "Culturi", "Siloz", "Animale", "Altele"],
+    "tr": ["İzlenen pazar kategorileri", "Ürünler", "Silaj", "Hayvancılık", "Diğer"],
+}
+
+
+def read(path):
+    return path.read_bytes().decode("utf-8-sig")
+
+
+def write(path, text):
+    path.write_bytes(text.encode("utf-8"))
+
+
+def esc(v):
+    return v.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def main():
+    files = sorted(HERE.glob("translation_*.xml"))
+    if not files:
+        print("no translation_*.xml found")
+        return 1
+
+    # Match the file's own indentation for the entries we insert.
+    changed = 0
+    for path in files:
+        lang = path.stem.split("_", 1)[1]
+        body = read(path)
+        vals = TEXTS.get(lang)
+
+        entries = []
+        for i, key in enumerate(KEYS):
+            if 'name="%s"' % key in body:
+                continue
+            value = vals[i] if vals else EN[key]
+            entries.append('        <text name="%s" text="%s" />' % (key, esc(value)))
+
+        if not entries:
+            continue
+
+        block = "\n".join(entries) + "\n"
+        new = re.sub(r"([ \t]*)</texts>", block + r"\1</texts>", body, count=1)
+        if new == body:
+            print("could not find </texts> in %s" % path.name)
+            return 1
+        write(path, new)
+        changed += 1
+
+    print("patched %d of %d translation file(s)" % (changed, len(files)))
+
+    bad = []
+    for path in files:
+        body = read(path)
+        for key in KEYS:
+            n = body.count('name="%s"' % key)
+            if n != 1:
+                bad.append("%s: %s x%d" % (path.name, key, n))
+    if bad:
+        print("VERIFY FAILED:")
+        for b in bad:
+            print("  " + b)
+        return 1
+    print("verified: all %d keys present exactly once in all %d files" % (len(KEYS), len(files)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Abrir gerenciador de trabalhadores" />
         <text name="sf_pda_btn_rotation_planner" text="Planejador de rotação" />
         <text name="sf_pda_btn_field_detail" text="Detalhe do campo" />
+        <text name="mdm_evt_tracked_label" text="Categorias de mercado monitoradas" />
+        <text name="mdm_cat_crops" text="Culturas" />
+        <text name="mdm_cat_silage" text="Silagem" />
+        <text name="mdm_cat_livestock" text="Gado" />
+        <text name="mdm_cat_other" text="Outros" />
+        <text name="mdm_screen_per_head" text="/ cabeça" />
+        <text name="mdm_screen_per_1000l" text="/ 1.000 L" />
+        <text name="mdm_screen_price_trend" text="Tendência de preços" />
+        <text name="mdm_screen_graph_oldest" text="mais antigo" />
+        <text name="mdm_screen_graph_newest" text="agora" />
+        <text name="mdm_screen_graph_span" text="%d amostras" />
+        <text name="mdm_screen_graph_median" text="Todas as mercadorias (mediana)" />
 </texts>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="開啟工人管理員" />
         <text name="sf_pda_btn_rotation_planner" text="輪作規劃" />
         <text name="sf_pda_btn_field_detail" text="田地詳情" />
+        <text name="mdm_evt_tracked_label" text="Tracked market categories" />
+        <text name="mdm_cat_crops" text="Crops" />
+        <text name="mdm_cat_silage" text="Silage" />
+        <text name="mdm_cat_livestock" text="Livestock" />
+        <text name="mdm_cat_other" text="Other" />
+        <text name="mdm_screen_per_head" text="/ head" />
+        <text name="mdm_screen_per_1000l" text="/ 1,000L" />
+        <text name="mdm_screen_price_trend" text="Price trend" />
+        <text name="mdm_screen_graph_oldest" text="oldest" />
+        <text name="mdm_screen_graph_newest" text="now" />
+        <text name="mdm_screen_graph_span" text="%d samples" />
+        <text name="mdm_screen_graph_median" text="All commodities (median)" />
 </texts>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Otevřít správce pracovníků" />
         <text name="sf_pda_btn_rotation_planner" text="Plánovač osevního postupu" />
         <text name="sf_pda_btn_field_detail" text="Detail pole" />
+        <text name="mdm_evt_tracked_label" text="Sledované kategorie trhu" />
+        <text name="mdm_cat_crops" text="Plodiny" />
+        <text name="mdm_cat_silage" text="Siláž" />
+        <text name="mdm_cat_livestock" text="Dobytek" />
+        <text name="mdm_cat_other" text="Ostatní" />
+        <text name="mdm_screen_per_head" text="/ kus" />
+        <text name="mdm_screen_per_1000l" text="/ 1 000 l" />
+        <text name="mdm_screen_price_trend" text="Vývoj cen" />
+        <text name="mdm_screen_graph_oldest" text="nejstarší" />
+        <text name="mdm_screen_graph_newest" text="nyní" />
+        <text name="mdm_screen_graph_span" text="%d vzorků" />
+        <text name="mdm_screen_graph_median" text="Všechny komodity (medián)" />
 </texts>
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Åbn medarbejderstyring" />
         <text name="sf_pda_btn_rotation_planner" text="Rotationsplanlægger" />
         <text name="sf_pda_btn_field_detail" text="Markdetaljer" />
+        <text name="mdm_evt_tracked_label" text="Fulgte markedskategorier" />
+        <text name="mdm_cat_crops" text="Afgrøder" />
+        <text name="mdm_cat_silage" text="Ensilage" />
+        <text name="mdm_cat_livestock" text="Husdyr" />
+        <text name="mdm_cat_other" text="Andet" />
+        <text name="mdm_screen_per_head" text="/ dyr" />
+        <text name="mdm_screen_per_1000l" text="/ 1.000 L" />
+        <text name="mdm_screen_price_trend" text="Prisudvikling" />
+        <text name="mdm_screen_graph_oldest" text="ældste" />
+        <text name="mdm_screen_graph_newest" text="nu" />
+        <text name="mdm_screen_graph_span" text="%d målinger" />
+        <text name="mdm_screen_graph_median" text="Alle varer (median)" />
 </texts>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -317,5 +317,17 @@
         <text name="wc_rf_pda_open_manager" text="Arbeitermanager öffnen" />
         <text name="sf_pda_btn_rotation_planner" text="Fruchtfolgeplaner" />
         <text name="sf_pda_btn_field_detail" text="Felddetails" />
+        <text name="mdm_evt_tracked_label" text="Erfasste Marktkategorien" />
+        <text name="mdm_cat_crops" text="Feldfrüchte" />
+        <text name="mdm_cat_silage" text="Silage" />
+        <text name="mdm_cat_livestock" text="Tierhaltung" />
+        <text name="mdm_cat_other" text="Sonstige" />
+        <text name="mdm_screen_per_head" text="/ Tier" />
+        <text name="mdm_screen_per_1000l" text="/ 1.000 l" />
+        <text name="mdm_screen_price_trend" text="Preisverlauf" />
+        <text name="mdm_screen_graph_oldest" text="älteste" />
+        <text name="mdm_screen_graph_newest" text="jetzt" />
+        <text name="mdm_screen_graph_span" text="%d Messwerte" />
+        <text name="mdm_screen_graph_median" text="Alle Waren (Median)" />
 </texts>
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabajadores" />
         <text name="sf_pda_btn_rotation_planner" text="Planificador de rotación" />
         <text name="sf_pda_btn_field_detail" text="Detalle del campo" />
+        <text name="mdm_evt_tracked_label" text="Categorías de mercado seguidas" />
+        <text name="mdm_cat_crops" text="Cultivos" />
+        <text name="mdm_cat_silage" text="Ensilado" />
+        <text name="mdm_cat_livestock" text="Ganado" />
+        <text name="mdm_cat_other" text="Otros" />
+        <text name="mdm_screen_per_head" text="/ cabeza" />
+        <text name="mdm_screen_per_1000l" text="/ 1.000 L" />
+        <text name="mdm_screen_price_trend" text="Tendencia de precios" />
+        <text name="mdm_screen_graph_oldest" text="más antiguo" />
+        <text name="mdm_screen_graph_newest" text="ahora" />
+        <text name="mdm_screen_graph_span" text="%d muestras" />
+        <text name="mdm_screen_graph_median" text="Todas las mercancías (mediana)" />
 </texts>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -357,5 +357,17 @@
         <text name="wc_rf_pda_open_manager" text="Open Worker Manager" />
         <text name="sf_pda_btn_rotation_planner" text="Rotation Planner" />
         <text name="sf_pda_btn_field_detail" text="Field Detail" />
+        <text name="mdm_evt_tracked_label" text="Tracked market categories" />
+        <text name="mdm_cat_crops" text="Crops" />
+        <text name="mdm_cat_silage" text="Silage" />
+        <text name="mdm_cat_livestock" text="Livestock" />
+        <text name="mdm_cat_other" text="Other" />
+        <text name="mdm_screen_per_head" text="/ head" />
+        <text name="mdm_screen_per_1000l" text="/ 1,000L" />
+        <text name="mdm_screen_price_trend" text="Price trend" />
+        <text name="mdm_screen_graph_oldest" text="oldest" />
+        <text name="mdm_screen_graph_newest" text="now" />
+        <text name="mdm_screen_graph_span" text="%d samples" />
+        <text name="mdm_screen_graph_median" text="All commodities (median)" />
 </texts>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabajadores" />
         <text name="sf_pda_btn_rotation_planner" text="Planificador de rotación" />
         <text name="sf_pda_btn_field_detail" text="Detalle del campo" />
+        <text name="mdm_evt_tracked_label" text="Categorías de mercado seguidas" />
+        <text name="mdm_cat_crops" text="Cultivos" />
+        <text name="mdm_cat_silage" text="Ensilado" />
+        <text name="mdm_cat_livestock" text="Ganado" />
+        <text name="mdm_cat_other" text="Otros" />
+        <text name="mdm_screen_per_head" text="/ cabeza" />
+        <text name="mdm_screen_per_1000l" text="/ 1.000 L" />
+        <text name="mdm_screen_price_trend" text="Tendencia de precios" />
+        <text name="mdm_screen_graph_oldest" text="más antiguo" />
+        <text name="mdm_screen_graph_newest" text="ahora" />
+        <text name="mdm_screen_graph_span" text="%d muestras" />
+        <text name="mdm_screen_graph_median" text="Todas las mercancías (mediana)" />
 </texts>
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Ouvrir le gestionnaire d'ouvriers" />
         <text name="sf_pda_btn_rotation_planner" text="Planificateur de rotation" />
         <text name="sf_pda_btn_field_detail" text="Détail du champ" />
+        <text name="mdm_evt_tracked_label" text="Tracked market categories" />
+        <text name="mdm_cat_crops" text="Crops" />
+        <text name="mdm_cat_silage" text="Silage" />
+        <text name="mdm_cat_livestock" text="Livestock" />
+        <text name="mdm_cat_other" text="Other" />
+        <text name="mdm_screen_per_head" text="/ head" />
+        <text name="mdm_screen_per_1000l" text="/ 1,000L" />
+        <text name="mdm_screen_price_trend" text="Price trend" />
+        <text name="mdm_screen_graph_oldest" text="oldest" />
+        <text name="mdm_screen_graph_newest" text="now" />
+        <text name="mdm_screen_graph_span" text="%d samples" />
+        <text name="mdm_screen_graph_median" text="All commodities (median)" />
 </texts>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Avaa työntekijähallinta" />
         <text name="sf_pda_btn_rotation_planner" text="Viljelykiertosuunnittelija" />
         <text name="sf_pda_btn_field_detail" text="Pellon tiedot" />
+        <text name="mdm_evt_tracked_label" text="Seuratut markkinaluokat" />
+        <text name="mdm_cat_crops" text="Viljelykasvit" />
+        <text name="mdm_cat_silage" text="Säilörehu" />
+        <text name="mdm_cat_livestock" text="Karja" />
+        <text name="mdm_cat_other" text="Muut" />
+        <text name="mdm_screen_per_head" text="/ eläin" />
+        <text name="mdm_screen_per_1000l" text="/ 1 000 l" />
+        <text name="mdm_screen_price_trend" text="Hintakehitys" />
+        <text name="mdm_screen_graph_oldest" text="vanhin" />
+        <text name="mdm_screen_graph_newest" text="nyt" />
+        <text name="mdm_screen_graph_span" text="%d näytettä" />
+        <text name="mdm_screen_graph_median" text="Kaikki tuotteet (mediaani)" />
 </texts>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -318,5 +318,17 @@
         <text name="wc_rf_pda_open_manager" text="Ouvrir le gestionnaire d'ouvriers" />
         <text name="sf_pda_btn_rotation_planner" text="Planificateur de rotation" />
         <text name="sf_pda_btn_field_detail" text="Détail du champ" />
+        <text name="mdm_evt_tracked_label" text="Catégories de marché suivies" />
+        <text name="mdm_cat_crops" text="Cultures" />
+        <text name="mdm_cat_silage" text="Ensilage" />
+        <text name="mdm_cat_livestock" text="Élevage" />
+        <text name="mdm_cat_other" text="Autres" />
+        <text name="mdm_screen_per_head" text="/ tête" />
+        <text name="mdm_screen_per_1000l" text="/ 1 000 L" />
+        <text name="mdm_screen_price_trend" text="Tendance des prix" />
+        <text name="mdm_screen_graph_oldest" text="plus ancien" />
+        <text name="mdm_screen_graph_newest" text="maintenant" />
+        <text name="mdm_screen_graph_span" text="%d relevés" />
+        <text name="mdm_screen_graph_median" text="Toutes les marchandises (médiane)" />
 </texts>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Dolgozókezelő megnyitása" />
         <text name="sf_pda_btn_rotation_planner" text="Vetésforgó-tervező" />
         <text name="sf_pda_btn_field_detail" text="Táblarészletek" />
+        <text name="mdm_evt_tracked_label" text="Követett piaci kategóriák" />
+        <text name="mdm_cat_crops" text="Növények" />
+        <text name="mdm_cat_silage" text="Szilázs" />
+        <text name="mdm_cat_livestock" text="Állatok" />
+        <text name="mdm_cat_other" text="Egyéb" />
+        <text name="mdm_screen_per_head" text="/ állat" />
+        <text name="mdm_screen_per_1000l" text="/ 1000 l" />
+        <text name="mdm_screen_price_trend" text="Ártrend" />
+        <text name="mdm_screen_graph_oldest" text="legrégebbi" />
+        <text name="mdm_screen_graph_newest" text="most" />
+        <text name="mdm_screen_graph_span" text="%d minta" />
+        <text name="mdm_screen_graph_median" text="Minden áru (medián)" />
 </texts>
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Buka manajer pekerja" />
         <text name="sf_pda_btn_rotation_planner" text="Perencana rotasi" />
         <text name="sf_pda_btn_field_detail" text="Detail lahan" />
+        <text name="mdm_evt_tracked_label" text="Tracked market categories" />
+        <text name="mdm_cat_crops" text="Crops" />
+        <text name="mdm_cat_silage" text="Silage" />
+        <text name="mdm_cat_livestock" text="Livestock" />
+        <text name="mdm_cat_other" text="Other" />
+        <text name="mdm_screen_per_head" text="/ head" />
+        <text name="mdm_screen_per_1000l" text="/ 1,000L" />
+        <text name="mdm_screen_price_trend" text="Price trend" />
+        <text name="mdm_screen_graph_oldest" text="oldest" />
+        <text name="mdm_screen_graph_newest" text="now" />
+        <text name="mdm_screen_graph_span" text="%d samples" />
+        <text name="mdm_screen_graph_median" text="All commodities (median)" />
 </texts>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Apri gestore operai" />
         <text name="sf_pda_btn_rotation_planner" text="Pianificatore rotazioni" />
         <text name="sf_pda_btn_field_detail" text="Dettaglio campo" />
+        <text name="mdm_evt_tracked_label" text="Categorie di mercato monitorate" />
+        <text name="mdm_cat_crops" text="Colture" />
+        <text name="mdm_cat_silage" text="Insilato" />
+        <text name="mdm_cat_livestock" text="Bestiame" />
+        <text name="mdm_cat_other" text="Altro" />
+        <text name="mdm_screen_per_head" text="/ capo" />
+        <text name="mdm_screen_per_1000l" text="/ 1.000 L" />
+        <text name="mdm_screen_price_trend" text="Andamento prezzi" />
+        <text name="mdm_screen_graph_oldest" text="meno recente" />
+        <text name="mdm_screen_graph_newest" text="ora" />
+        <text name="mdm_screen_graph_span" text="%d campioni" />
+        <text name="mdm_screen_graph_median" text="Tutte le merci (mediana)" />
 </texts>
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="作業員マネージャーを開く" />
         <text name="sf_pda_btn_rotation_planner" text="輪作プランナー" />
         <text name="sf_pda_btn_field_detail" text="畑の詳細" />
+        <text name="mdm_evt_tracked_label" text="Tracked market categories" />
+        <text name="mdm_cat_crops" text="Crops" />
+        <text name="mdm_cat_silage" text="Silage" />
+        <text name="mdm_cat_livestock" text="Livestock" />
+        <text name="mdm_cat_other" text="Other" />
+        <text name="mdm_screen_per_head" text="/ head" />
+        <text name="mdm_screen_per_1000l" text="/ 1,000L" />
+        <text name="mdm_screen_price_trend" text="Price trend" />
+        <text name="mdm_screen_graph_oldest" text="oldest" />
+        <text name="mdm_screen_graph_newest" text="now" />
+        <text name="mdm_screen_graph_span" text="%d samples" />
+        <text name="mdm_screen_graph_median" text="All commodities (median)" />
 </texts>
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="작업자 관리자 열기" />
         <text name="sf_pda_btn_rotation_planner" text="윤작 계획기" />
         <text name="sf_pda_btn_field_detail" text="밯 상세" />
+        <text name="mdm_evt_tracked_label" text="Tracked market categories" />
+        <text name="mdm_cat_crops" text="Crops" />
+        <text name="mdm_cat_silage" text="Silage" />
+        <text name="mdm_cat_livestock" text="Livestock" />
+        <text name="mdm_cat_other" text="Other" />
+        <text name="mdm_screen_per_head" text="/ head" />
+        <text name="mdm_screen_per_1000l" text="/ 1,000L" />
+        <text name="mdm_screen_price_trend" text="Price trend" />
+        <text name="mdm_screen_graph_oldest" text="oldest" />
+        <text name="mdm_screen_graph_newest" text="now" />
+        <text name="mdm_screen_graph_span" text="%d samples" />
+        <text name="mdm_screen_graph_median" text="All commodities (median)" />
 </texts>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -313,5 +313,17 @@
         <text name="wc_rf_pda_open_manager" text="Werkersbeheer openen" />
         <text name="sf_pda_btn_rotation_planner" text="Rotatieplanner" />
         <text name="sf_pda_btn_field_detail" text="Veldgegevens" />
+        <text name="mdm_evt_tracked_label" text="Gevolgde marktcategorieën" />
+        <text name="mdm_cat_crops" text="Gewassen" />
+        <text name="mdm_cat_silage" text="Kuilvoer" />
+        <text name="mdm_cat_livestock" text="Vee" />
+        <text name="mdm_cat_other" text="Overig" />
+        <text name="mdm_screen_per_head" text="/ dier" />
+        <text name="mdm_screen_per_1000l" text="/ 1.000 L" />
+        <text name="mdm_screen_price_trend" text="Prijsverloop" />
+        <text name="mdm_screen_graph_oldest" text="oudste" />
+        <text name="mdm_screen_graph_newest" text="nu" />
+        <text name="mdm_screen_graph_span" text="%d metingen" />
+        <text name="mdm_screen_graph_median" text="Alle goederen (mediaan)" />
 </texts>
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Åpne arbeiderbehandler" />
         <text name="sf_pda_btn_rotation_planner" text="Rotasjonsplanlegger" />
         <text name="sf_pda_btn_field_detail" text="Feltdetaljer" />
+        <text name="mdm_evt_tracked_label" text="Fulgte markedskategorier" />
+        <text name="mdm_cat_crops" text="Vekster" />
+        <text name="mdm_cat_silage" text="Silo" />
+        <text name="mdm_cat_livestock" text="Husdyr" />
+        <text name="mdm_cat_other" text="Annet" />
+        <text name="mdm_screen_per_head" text="/ dyr" />
+        <text name="mdm_screen_per_1000l" text="/ 1 000 L" />
+        <text name="mdm_screen_price_trend" text="Prisutvikling" />
+        <text name="mdm_screen_graph_oldest" text="eldste" />
+        <text name="mdm_screen_graph_newest" text="nå" />
+        <text name="mdm_screen_graph_span" text="%d målinger" />
+        <text name="mdm_screen_graph_median" text="Alle varer (median)" />
 </texts>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Otwórz menedżera pracowników" />
         <text name="sf_pda_btn_rotation_planner" text="Planer płodozmianu" />
         <text name="sf_pda_btn_field_detail" text="Szczegóły pola" />
+        <text name="mdm_evt_tracked_label" text="Śledzone kategorie rynku" />
+        <text name="mdm_cat_crops" text="Uprawy" />
+        <text name="mdm_cat_silage" text="Kiszonka" />
+        <text name="mdm_cat_livestock" text="Zwierzęta" />
+        <text name="mdm_cat_other" text="Inne" />
+        <text name="mdm_screen_per_head" text="/ szt." />
+        <text name="mdm_screen_per_1000l" text="/ 1000 l" />
+        <text name="mdm_screen_price_trend" text="Trend cen" />
+        <text name="mdm_screen_graph_oldest" text="najstarsze" />
+        <text name="mdm_screen_graph_newest" text="teraz" />
+        <text name="mdm_screen_graph_span" text="%d próbek" />
+        <text name="mdm_screen_graph_median" text="Wszystkie towary (mediana)" />
 </texts>
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabalhadores" />
         <text name="sf_pda_btn_rotation_planner" text="Planeador de rotação" />
         <text name="sf_pda_btn_field_detail" text="Detalhe do campo" />
+        <text name="mdm_evt_tracked_label" text="Categorias de mercado seguidas" />
+        <text name="mdm_cat_crops" text="Culturas" />
+        <text name="mdm_cat_silage" text="Silagem" />
+        <text name="mdm_cat_livestock" text="Gado" />
+        <text name="mdm_cat_other" text="Outros" />
+        <text name="mdm_screen_per_head" text="/ cabeça" />
+        <text name="mdm_screen_per_1000l" text="/ 1.000 L" />
+        <text name="mdm_screen_price_trend" text="Tendência de preços" />
+        <text name="mdm_screen_graph_oldest" text="mais antigo" />
+        <text name="mdm_screen_graph_newest" text="agora" />
+        <text name="mdm_screen_graph_span" text="%d amostras" />
+        <text name="mdm_screen_graph_median" text="Todas as mercadorias (mediana)" />
 </texts>
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Deschide managerul de muncitori" />
         <text name="sf_pda_btn_rotation_planner" text="Planificator de rotație" />
         <text name="sf_pda_btn_field_detail" text="Detaliu câmp" />
+        <text name="mdm_evt_tracked_label" text="Categorii de piață urmărite" />
+        <text name="mdm_cat_crops" text="Culturi" />
+        <text name="mdm_cat_silage" text="Siloz" />
+        <text name="mdm_cat_livestock" text="Animale" />
+        <text name="mdm_cat_other" text="Altele" />
+        <text name="mdm_screen_per_head" text="/ cap" />
+        <text name="mdm_screen_per_1000l" text="/ 1.000 L" />
+        <text name="mdm_screen_price_trend" text="Tendința prețurilor" />
+        <text name="mdm_screen_graph_oldest" text="cel mai vechi" />
+        <text name="mdm_screen_graph_newest" text="acum" />
+        <text name="mdm_screen_graph_span" text="%d probe" />
+        <text name="mdm_screen_graph_median" text="Toate mărfurile (mediană)" />
 </texts>
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Открыть менеджер работников" />
         <text name="sf_pda_btn_rotation_planner" text="Планировщик севооборота" />
         <text name="sf_pda_btn_field_detail" text="Сведения о поле" />
+        <text name="mdm_evt_tracked_label" text="Отслеживаемые категории рынка" />
+        <text name="mdm_cat_crops" text="Культуры" />
+        <text name="mdm_cat_silage" text="Силос" />
+        <text name="mdm_cat_livestock" text="Скот" />
+        <text name="mdm_cat_other" text="Прочее" />
+        <text name="mdm_screen_per_head" text="/ голову" />
+        <text name="mdm_screen_per_1000l" text="/ 1 000 л" />
+        <text name="mdm_screen_price_trend" text="Динамика цен" />
+        <text name="mdm_screen_graph_oldest" text="ранее" />
+        <text name="mdm_screen_graph_newest" text="сейчас" />
+        <text name="mdm_screen_graph_span" text="%d замеров" />
+        <text name="mdm_screen_graph_median" text="Все товары (медиана)" />
 </texts>
 </l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Öppna arbetshanteraren" />
         <text name="sf_pda_btn_rotation_planner" text="Växtföljdsplanerare" />
         <text name="sf_pda_btn_field_detail" text="Fältdetaljer" />
+        <text name="mdm_evt_tracked_label" text="Följda marknadskategorier" />
+        <text name="mdm_cat_crops" text="Grödor" />
+        <text name="mdm_cat_silage" text="Ensilage" />
+        <text name="mdm_cat_livestock" text="Boskap" />
+        <text name="mdm_cat_other" text="Övrigt" />
+        <text name="mdm_screen_per_head" text="/ djur" />
+        <text name="mdm_screen_per_1000l" text="/ 1 000 L" />
+        <text name="mdm_screen_price_trend" text="Prisutveckling" />
+        <text name="mdm_screen_graph_oldest" text="äldsta" />
+        <text name="mdm_screen_graph_newest" text="nu" />
+        <text name="mdm_screen_graph_span" text="%d mätvärden" />
+        <text name="mdm_screen_graph_median" text="Alla varor (median)" />
 </texts>
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="İşçi yöneticisini aç" />
         <text name="sf_pda_btn_rotation_planner" text="Ekim nöbeti planlayıcı" />
         <text name="sf_pda_btn_field_detail" text="Tarla detayı" />
+        <text name="mdm_evt_tracked_label" text="İzlenen pazar kategorileri" />
+        <text name="mdm_cat_crops" text="Ürünler" />
+        <text name="mdm_cat_silage" text="Silaj" />
+        <text name="mdm_cat_livestock" text="Hayvancılık" />
+        <text name="mdm_cat_other" text="Diğer" />
+        <text name="mdm_screen_per_head" text="/ baş" />
+        <text name="mdm_screen_per_1000l" text="/ 1.000 L" />
+        <text name="mdm_screen_price_trend" text="Fiyat eğilimi" />
+        <text name="mdm_screen_graph_oldest" text="en eski" />
+        <text name="mdm_screen_graph_newest" text="şimdi" />
+        <text name="mdm_screen_graph_span" text="%d örnek" />
+        <text name="mdm_screen_graph_median" text="Tüm ürünler (medyan)" />
 </texts>
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Відкрити менеджер працівників" />
         <text name="sf_pda_btn_rotation_planner" text="Планувальник сівозміни" />
         <text name="sf_pda_btn_field_detail" text="Деталі поля" />
+        <text name="mdm_evt_tracked_label" text="Відстежувані категорії ринку" />
+        <text name="mdm_cat_crops" text="Культури" />
+        <text name="mdm_cat_silage" text="Силос" />
+        <text name="mdm_cat_livestock" text="Худоба" />
+        <text name="mdm_cat_other" text="Інше" />
+        <text name="mdm_screen_per_head" text="/ голову" />
+        <text name="mdm_screen_per_1000l" text="/ 1 000 л" />
+        <text name="mdm_screen_price_trend" text="Динаміка цін" />
+        <text name="mdm_screen_graph_oldest" text="раніше" />
+        <text name="mdm_screen_graph_newest" text="зараз" />
+        <text name="mdm_screen_graph_span" text="%d замірів" />
+        <text name="mdm_screen_graph_median" text="Усі товари (медіана)" />
 </texts>
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <l10n>
     <texts>
 
@@ -311,5 +311,17 @@
         <text name="wc_rf_pda_open_manager" text="Mở trình quản lý công nhân" />
         <text name="sf_pda_btn_rotation_planner" text="Lập kế hoạch luân canh" />
         <text name="sf_pda_btn_field_detail" text="Chi tiết thửa ruộng" />
+        <text name="mdm_evt_tracked_label" text="Tracked market categories" />
+        <text name="mdm_cat_crops" text="Crops" />
+        <text name="mdm_cat_silage" text="Silage" />
+        <text name="mdm_cat_livestock" text="Livestock" />
+        <text name="mdm_cat_other" text="Other" />
+        <text name="mdm_screen_per_head" text="/ head" />
+        <text name="mdm_screen_per_1000l" text="/ 1,000L" />
+        <text name="mdm_screen_price_trend" text="Price trend" />
+        <text name="mdm_screen_graph_oldest" text="oldest" />
+        <text name="mdm_screen_graph_newest" text="now" />
+        <text name="mdm_screen_graph_span" text="%d samples" />
+        <text name="mdm_screen_graph_median" text="All commodities (median)" />
 </texts>
 </l10n>

--- a/xml/gui/MDMEventSettingsDialog.xml
+++ b/xml/gui/MDMEventSettingsDialog.xml
@@ -66,7 +66,9 @@
       <Text profile="mdmEvtS_colHdr" text="$l10n_mdm_col_status"        position="258px -222px" size="115px 24px"/>
       <Text profile="mdmEvtS_colHdr" text="$l10n_mdm_col_custom_fills"  position="380px -222px" size="75px 24px"/>
       <Text profile="mdmEvtS_colHdr" text=""              position="462px -222px" size="90px 24px"/>
-      <Text profile="mdmEvtS_colHdr" text="$l10n_mdm_col_test"          position="558px -222px" size="135px 24px"/>
+      <!-- BUILD 15:39 (PB-08): dev-only column, hidden unless debugMode is on.
+           _refreshEventRows drives it via evtSColHdrTest. -->
+      <Text profile="mdmEvtS_colHdr" id="evtSColHdrTest" text="$l10n_mdm_col_test" position="558px -222px" size="135px 24px" visible="false"/>
 
       <!-- ── Row 0 ── -->
       <Text   profile="mdmEvtS_evtName" id="evtRowName0"     text="" position="0px -254px"   size="250px 28px" visible="false"/>
@@ -191,7 +193,10 @@
 
       <!-- ═══ FILL TYPE REFERENCE ═══ -->
       <Bitmap profile="mdmEvtS_sep" position="0px -618px" size="700px 2px"/>
-      <Text profile="mdmEvtS_sectionLabel" text="TRACKED FILL TYPES" position="0px -634px" size="300px 20px"/>
+      <!-- BUILD 15:39 (PB-08): the label was a hardcoded English internal-sounding
+           heading over a list of raw engine keys. It is localised now, and the
+           list underneath is plain categories unless debugMode is on. -->
+      <Text profile="mdmEvtS_sectionLabel" id="evtSFillTypeLabel" text="$l10n_mdm_evt_tracked_label" position="0px -634px" size="300px 20px"/>
       <Text profile="mdmEvtS_ftHint" id="evtSFillTypeHint" text="" position="0px -654px" size="700px 38px"/>
 
     </GuiElement>

--- a/xml/gui/MarketScreen.xml
+++ b/xml/gui/MarketScreen.xml
@@ -140,15 +140,21 @@
 
         <!-- tabBar LAST: FS25 processes mouse events in reverse XML order.
              Declared after all content panels so it gets click priority. -->
+        <!-- BUILD 15:39 (PB-04). The hit Buttons used to sit at y=0 while their
+             labels sat at y=28 in the same 30px bar, so the rectangle that
+             answers a click was never underneath the words the player can see.
+             Clicking Events or Contracts hit empty bar and Prices stayed
+             selected. Button and label now share one anchor, one position and
+             one size, so the engine's own ButtonElement dispatch fires. -->
         <GuiElement id="tabBar" profile="emptyPanel" position="0px 668px" width="1000px" height="30px">
-          <Button profile="mdm_tabBtnHit" onClick="onClickTabPrices"    position="0px 0px"   size="160px 28px"/>
-          <Text   profile="mdm_tabLabel"  id="tabLabelPrices"    text="$l10n_mdm_screen_tab_prices"    onClick="onClickTabPrices"    position="0px 28px"   size="160px 28px"/>
+          <Button profile="mdm_tabBtnHit" id="tabHitPrices"    onClick="onClickTabPrices"    position="0px 28px"   size="160px 28px"/>
+          <Text   profile="mdm_tabLabel"  id="tabLabelPrices"    text="$l10n_mdm_screen_tab_prices"    position="0px 28px"   size="160px 28px"/>
           <Bitmap profile="mdm_tabUnderline" id="tabUnderlinePrices"    position="0px 0px"   size="160px 2px"/>
-          <Button profile="mdm_tabBtnHit" onClick="onClickTabEvents"    position="170px 0px" size="160px 28px"/>
-          <Text   profile="mdm_tabLabel"  id="tabLabelEvents"    text="$l10n_mdm_screen_tab_events"    onClick="onClickTabEvents"    position="170px 28px" size="160px 28px"/>
+          <Button profile="mdm_tabBtnHit" id="tabHitEvents"    onClick="onClickTabEvents"    position="170px 28px" size="160px 28px"/>
+          <Text   profile="mdm_tabLabel"  id="tabLabelEvents"    text="$l10n_mdm_screen_tab_events"    position="170px 28px" size="160px 28px"/>
           <Bitmap profile="mdm_tabUnderline" id="tabUnderlineEvents"    position="170px 0px" size="160px 2px" visible="false"/>
-          <Button profile="mdm_tabBtnHit" onClick="onClickTabContracts" position="340px 0px" size="200px 28px"/>
-          <Text   profile="mdm_tabLabel"  id="tabLabelContracts" text="$l10n_mdm_screen_tab_contracts" onClick="onClickTabContracts" position="340px 28px" size="200px 28px"/>
+          <Button profile="mdm_tabBtnHit" id="tabHitContracts" onClick="onClickTabContracts" position="340px 28px" size="200px 28px"/>
+          <Text   profile="mdm_tabLabel"  id="tabLabelContracts" text="$l10n_mdm_screen_tab_contracts" position="340px 28px" size="200px 28px"/>
           <Bitmap profile="mdm_tabUnderline" id="tabUnderlineContracts" position="340px 0px" size="200px 2px" visible="false"/>
         </GuiElement>
         <Bitmap profile="mdm_tabDivider" position="0px 666px" size="1000px 2px"/>
@@ -166,11 +172,16 @@
       <imageFilename value="g_MDMIconMenu"/>
       <imageColor value="$preset_fs25_colorMainDark"/>
     </Profile>
-    <!-- Invisible hit area for tab clicks — UsedPlus fmfRowHit pattern -->
-    <Profile name="mdm_tabBtnHit" extends="emptyPanel">
+    <!-- Invisible hit area for tab clicks - UsedPlus fmfRowHit pattern.
+         BUILD 15:39 (PB-04): the anchor is now explicit and matches
+         mdm_tabLabel, so "same position" in the XML really is the same rect. -->
+    <Profile name="mdm_tabBtnHit" extends="emptyPanel" with="anchorTopLeft">
       <isFocusable value="true"/>
     </Profile>
-    <!-- Visual tab label — isFocusable so it receives mouse clicks as a fallback hit target -->
+    <!-- Visual tab label. A Text element does not dispatch mouse clicks, so it
+         carries no onClick: the co-located mdm_tabBtnHit Button above it is the
+         control, and MarketScreen:mouseEvent hit-tests the same rect as a
+         belt-and-braces fallback. -->
     <Profile name="mdm_tabLabel" extends="fs25_textDefault" with="anchorTopLeft">
       <isFocusable value="true"/>
       <textSize value="14px"/>

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -22,9 +22,13 @@
             </ThreePartBitmap>
 
             <Bitmap profile="fs25_subCategoryContainer" id="rfFilterBox">
-                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
-                                 disableButtonsOnSingleText="false"
-                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
+                <!-- BUILD 18:16: rfPanelSelector moved to LAST child of rfFilterBox (see below).
+                     George TASK 18:12 asked for z-order ~10-20 on the selector; this engine has no
+                     z attribute of any kind (GuiElement loads none, and no rfHeaderBg element exists
+                     in this page) - draw AND input priority are declaration order, walked in reverse
+                     for events. Declaring the selector last IS the engine's z-raise: it now receives
+                     events before every sibling in this box and draws above them. Positions are
+                     profile-absolute, so nothing moves a pixel. -->
                 <BoxLayout profile="fs25_subCategorySelectorBox" id="rfPanelDotBox">
                     <RoundCorner profile="fs25_subCategorySelectorDot" id="rfPanelDotTemplate"/>
                 </BoxLayout>
@@ -60,6 +64,16 @@
                         <Slider profile="fs25_listSlider" dataElementId="moduleList" hideParentWhenEmpty="true"/>
                     </ThreePartBitmap>
                 </GuiElement>
+
+                <!-- BUILD 18:16 (George TASK 18:12): the module selector is deliberately the LAST
+                     child of rfFilterBox. Events walk children in reverse declaration order, so
+                     last-declared = first offered = this engine's only "z-order raise". Its band
+                     rect (profile-positioned, unchanged) does not overlap any sibling's visible
+                     paint, so drawing on top changes no pixel. The BUILD 17:08 page-level click
+                     shield stays as the guarantee against anything OUTSIDE this box. -->
+                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
+                                 disableButtonsOnSingleText="false"
+                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
             </Bitmap>
 
             <!-- WC page chrome: sibling under Modules (NOT inside rfFilterBox — hit hygiene).
@@ -222,29 +236,43 @@
                              built by whichever mod loads first, from its own copy, so a change
                              in Soil alone would be overwritten by whoever won the race. -->
                         <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px" size="620px 248px">
-                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="600px 20px"
+                            <!-- BUILD 09:19 (PB-05). Brian read "Wait: amending now can burn t..." on
+                                 this strip: the sentence that says an apply will scorch the crop was
+                                 cut before its own verb.
+                                 The wrap was not broken. TextElement defaults to LAYOUT_MODE.TRUNCATE
+                                 (TextElement.lua:141) and with textMaxNumLines > 1 that takes the
+                                 limitVerticalLines path (:667-676), wrapping at absSize[1] and then
+                                 chopping characters until the text fits the line budget before adding
+                                 "..." (:679-699). So it wrapped to its two lines exactly as asked and
+                                 the string is simply longer than two lines of 18px across 600px.
+                                 Two allowed 18px lines become three. The 18px comes out of this zone
+                                 rather than out of the table: Selected moves up 2, the hairline and
+                                 the PRODUCTS heading close up, and the eight-row clip drops 4. Row 8
+                                 still ends 4px clear of the card frame (124 + 120 = 244 against 248),
+                                 so nothing is cut mid-glyph and the card does not grow. -->
+                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -4px" size="600px 20px"
                                   textAlignment="left"/>
-                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="600px 36px"
-                                  textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then ~16px of
-                                 air with one 1px hairline centred in it, then the PRODUCTS table.
+                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -24px" size="600px 54px"
+                                  textAlignment="left" textMaxNumLines="3" textVerticalAlignment="top"/>
+                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then air with
+                                 one 1px hairline in it, then the PRODUCTS table.
                                  One outer outline only; the rule is a Bitmap, not a second frame.
                                  Bodies inset X 0 -> 10 and widths 560 -> 540 so nothing kisses the
                                  white stroke on either side. -->
-                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="600px 1px"/>
-                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="600px 18px"
+                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -82px" size="600px 1px"/>
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -86px" size="600px 18px"
                                   text="$l10n_rf_pda_treat_products"/>
-                            <Text profile="RF_ProductColHeaderDense" position="10px -100px" size="40px 16px" text="NUT"/>
-                            <Text profile="RF_ProductColHeaderDense" position="54px -100px" size="270px 16px" text="PRODUCT"/>
-                            <Text profile="RF_ProductColHeaderDense" position="330px -100px" size="100px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="10px -106px" size="40px 16px" text="NUT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="54px -106px" size="270px 16px" text="PRODUCT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="330px -106px" size="100px 16px"
                                   textAlignment="right" text="RATE"/>
-                            <Text profile="RF_ProductColHeaderDense" position="440px -100px" size="110px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="440px -106px" size="110px 16px"
                                   textAlignment="right" text="TOTAL"/>
-                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="600px 22px"
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -124px" size="600px 22px"
                                   visible="false"/>
                             <!-- Clip sized to exactly the eight densified rows (8 x 15 = 120), so the
-                                 card bottom keeps 8px of air instead of cutting row 8 mid-glyph. -->
-                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="600px 120px">
+                                 card bottom keeps air instead of cutting row 8 mid-glyph. -->
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -124px" size="600px 120px">
                                 <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd1Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd1Name" position="44px 0px" size="270px 15px"/>
@@ -312,20 +340,43 @@
                             <Text profile="RF_ProductCell" id="soilRotationStatus" position="10px -56px" size="270px 20px"/>
                             <Text profile="RF_ProductCell" id="soilRotationTip" position="10px -76px" size="270px 32px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -116px" size="270px 1px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -124px" size="270px 16px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -144px" size="92px 14px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -144px" size="60px 14px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -144px" size="110px 14px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -162px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -162px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Effect" position="170px -162px" size="110px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -184px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -184px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Effect" position="170px -184px" size="110px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -206px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -206px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Effect" position="170px -206px" size="110px 18px"/>
+                            <!-- BUILD 09:19 (PB-05). The WHAT IF effect column lost whole consequences.
+                                 RotationPlannerData.effectText joins at most three items with ", " and
+                                 the set is closed: fatigue "x1.15 depletion", nitrogen "+N", and one of
+                                 "less disease" / "more disease". The worst real string is therefore
+                                 "x1.15 depletion, +N, less disease" at 33 characters, and the painter
+                                 capped the cell at 18 - so even the two-item "x1.15 depletion, +N" (19)
+                                 dropped an item and the player was told about the fatigue but not about
+                                 the disease.
+                                 18 was not arbitrary against the OLD cell: this card's own calibration
+                                 is ~6px per glyph at 17px (crop 92px/16, status 60px/10, effect 110px/18),
+                                 so 110px really does hold about 18. One 17px line cannot hold 33 and the
+                                 card cannot grow - George holds the footprint at 290x248 and it must
+                                 never take width back from PRODUCTS. So the effect cell gains a SECOND
+                                 line at 14px instead, which is the size the PRODUCTS table already uses
+                                 for its own cells (RF_ProductCellDense), and about 22 glyphs a line at
+                                 that size gives ~44 against a bounded worst case of 33.
+                                 Row pitch 22 -> 30 to hold the taller cell; the hairline and the two
+                                 header lines close up by 4-8px to pay for it. Row 3 ends at 240 against
+                                 the 248 frame, so the card keeps its 8px of bottom air. Crop and Status
+                                 stay one 17px line and are unchanged. -->
+                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -112px" size="270px 1px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -118px" size="270px 16px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -136px" size="92px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -136px" size="60px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -136px" size="110px 14px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -152px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -152px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf1Effect" position="170px -152px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -182px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -182px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf2Effect" position="170px -182px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -212px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -212px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf3Effect" position="170px -212px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
                         </GuiElement>
 
                         <!-- Col 3: sampling — shifted right so widened PRODUCTS does not overlap -->
@@ -526,6 +577,19 @@
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <!-- BUILD 09:19 (PB-07): row pager for this static eight-row table.
+                                 Hidden by default and shown ONLY by a guest that implements
+                                 onPageStep, so Income / Dairy / Depot keep exactly the page they
+                                 have today. Two Buttons, not a SmoothList: George's standing NO-GO
+                                 on nesting a SmoothList in this page (see csConsultPanel below)
+                                 applies here too, and a window offset held by the guest cannot
+                                 re-enter the layout the way a list rebuild can.
+                                 Parked on the rfFwTableTitle band, which every Table-mode guest
+                                 already hides, so the pager collides with nothing that paints. -->
+                            <Button profile="buttonActivate" id="rfFwPagePrev" position="880px -8px" size="120px 24px"
+                                    visible="false" text="" onClick="onClickRfFwPagePrev"/>
+                            <Button profile="buttonActivate" id="rfFwPageNext" position="1010px -8px" size="120px 24px"
+                                    visible="false" text="" onClick="onClickRfFwPageNext"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
                             <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <GUIProfiles>
     <!-- ============================================================ -->
     <!-- Realistic Farming PDA profiles — MOCKUP-ESC-RF-PDA swatches  -->
@@ -260,6 +260,16 @@
     </Profile>
     <Profile name="RF_ProductCellRight" extends="RF_ProductCell">
         <textAlignment value="right"/>
+    </Profile>
+    <!-- BUILD 09:19 (PB-05): WHAT IF effect cell only. Two lines at the same 14px the
+         PRODUCTS table already uses for its own cells, so a comma-joined consequence is
+         printed whole instead of losing its last item to a one-line 110px column. Top
+         aligned because a two-line cell that centres would not line up with the one-line
+         Crop and Status cells beside it. -->
+    <Profile name="RF_ProductCellEffect" extends="RF_ProductCell">
+        <textSize value="14px"/>
+        <textMaxNumLines value="2"/>
+        <textVerticalAlignment value="top"/>
     </Profile>
     <Profile name="RF_ProductOk" extends="fs25_textDefault" with="anchorTopLeft">
         <textSize value="18px"/>


### PR DESCRIPTION
## Summary
- Upgrades MarketDynamics HUD to base-game styling matching suite standards.
- Adds drag, corner scale, and edge width resizing.
- Connects to MasterHUD global toggle and edit mode.

## Test plan
- Verified in-game: MDM HUD displays with clean base-game chrome and respects layout controls.