### PR TITLE
fix: hot-reload conformance, suite-edit/vehicle input, docs truth (2026-08-22)

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -5,13 +5,13 @@
 -- Authors: TheCodingDad (tison) — core systems
 --          LeGrizzly             — GUI systems
 
-local modDirectory = g_currentModDirectory
-local modName      = g_currentModName
+local modDirectory = (MarketDynamicsModDirectory or g_currentModDirectory)
+local modName      = (MarketDynamicsModName or g_currentModName)
 
 source(modDirectory .. "src/integrations/OptionScalingResolver.lua")
 
 -- Menu icon global (resolved by XML imageFilename via hook below)
-g_MDMIconMenu = Utils.getFilename("images/menuIcon.dds", g_currentModDirectory)
+g_MDMIconMenu = Utils.getFilename("images/menuIcon.dds", (MarketDynamicsModDirectory or g_currentModDirectory))
 
 -- Resolve mod icon globals in XML imageFilename attributes (EmployeeManager pattern)
 local MDM_ICON_GLOBALS = {

--- a/src/BCIntegration.lua
+++ b/src/BCIntegration.lua
@@ -24,7 +24,7 @@
 -- Detection: g_modManager:getModByName("FS25_FuturesMission")
 -- Author: tison (dev-1)
 
-BCIntegration = {}
+BCIntegration = BCIntegration or {}
 
 -- ---------------------------------------------------------------------------
 -- Config

--- a/src/DebugHUD.lua
+++ b/src/DebugHUD.lua
@@ -7,7 +7,7 @@
 --
 -- Author: tison (dev-1)
 
-MDMDebugHUD = {}
+MDMDebugHUD = MDMDebugHUD or {}
 MDMDebugHUD.__index = MDMDebugHUD
 
 -- Layout

--- a/src/FuturesMarket.lua
+++ b/src/FuturesMarket.lua
@@ -17,7 +17,7 @@
 --
 -- Author: tison (dev-1)
 
-FuturesMarket = {}
+FuturesMarket = FuturesMarket or {}
 FuturesMarket.__index = FuturesMarket
 
 -- Base penalty rate for defaulting on a contract (fraction of unfulfilled contract value).

--- a/src/Logger.lua
+++ b/src/Logger.lua
@@ -1,3 +1,10 @@
+-- Hot-reload latch: g_currentModDirectory/Name are nil on live re-source;
+-- latched into module globals on first load (FuelCosts reference pattern).
+MarketDynamicsModDirectory = MarketDynamicsModDirectory
+    or g_currentModDirectory
+    or (g_modsDirectory ~= nil and (g_modsDirectory .. "FS25_MarketDynamics/") or nil)
+MarketDynamicsModName = MarketDynamicsModName or g_currentModName or "FS25_MarketDynamics"
+
 -- Logger.lua
 -- [MDM]-prefixed logging helper. Wraps FS25's Logging.* functions so all
 -- mod output is consistently prefixed and easy to grep in log.txt.
@@ -13,7 +20,7 @@
 --
 -- Author: tison (dev-1)
 
-MDMLog = {}
+MDMLog = MDMLog or {}
 
 local PREFIX = "[MDM] "
 
@@ -44,10 +51,10 @@ MDMLog.debugEnabled = false
 -- ---------------------------------------------------------------------------
 -- MDMUtil — shared utilities available to all MDM modules
 -- ---------------------------------------------------------------------------
-MDMUtil = {}
+MDMUtil = MDMUtil or {}
 
 -- Captured at load so event/notify paths keep MDM modEnv even if caller context shifts.
-local MDM_MOD_NAME = g_currentModName
+local MDM_MOD_NAME = (MarketDynamicsModName or g_currentModName)
 
 -- Mod-scoped i18n with Missing-reject (same spirit as MdRfPdaGuest.tr).
 -- Giants g_i18n:getText returns a truthy "Missing '…'" banner on miss; never paint that.

--- a/src/MDMEventConfig.lua
+++ b/src/MDMEventConfig.lua
@@ -12,7 +12,7 @@
 --
 -- Author: tison (dev-1)
 
-MDMEventConfig = {}
+MDMEventConfig = MDMEventConfig or {}
 
 -- Returns the active extra fill type list for an event from settings.
 local function _getList(eventId)

--- a/src/MDMMasterHUDBridge.lua
+++ b/src/MDMMasterHUDBridge.lua
@@ -21,7 +21,7 @@
 -- The cross-mod handle is g_currentMission.masterHUD (published in Mission00.load).
 -- =========================================================
 
-MDMMasterHUDBridge = {}
+MDMMasterHUDBridge = MDMMasterHUDBridge or {}
 
 MDMMasterHUDBridge.HUD_ID = "MarketDynamics_HUD"
 MDMMasterHUDBridge.active = false   -- MasterHUD present and we registered

--- a/src/MDMNetworkSyncBridge.lua
+++ b/src/MDMNetworkSyncBridge.lua
@@ -32,7 +32,7 @@
 -- (server and client always run the same registerAction / requestAction call).
 -- =========================================================
 
-MDMNetworkSyncBridge = {}
+MDMNetworkSyncBridge = MDMNetworkSyncBridge or {}
 
 MDMNetworkSyncBridge.ACTION_ID = "MarketDynamics_Contract"
 

--- a/src/MDMSettingsHubBridge.lua
+++ b/src/MDMSettingsHubBridge.lua
@@ -14,7 +14,7 @@
 -- now, so applyChange only needs to set the value back on that table.
 -- =========================================================
 
-MDMSettingsHubBridge = {}
+MDMSettingsHubBridge = MDMSettingsHubBridge or {}
 
 local function applyChange(key, value)
     local mdm = g_MarketDynamics

--- a/src/MDMStateLedgerBridge.lua
+++ b/src/MDMStateLedgerBridge.lua
@@ -33,7 +33,7 @@
 -- The cross-mod handle is g_currentMission.stateLedger (published in Mission00.load).
 -- =========================================================
 
-MDMStateLedgerBridge = {}
+MDMStateLedgerBridge = MDMStateLedgerBridge or {}
 
 -- Provisional persistence key. This is the KEY inside the master file, so it must
 -- be locked with Claude(A) before any release (a later rename orphans saved market

--- a/src/MarketDynamics.lua
+++ b/src/MarketDynamics.lua
@@ -19,7 +19,7 @@
 --
 -- Author: tison (dev-1)
 
-MarketDynamics = {}
+MarketDynamics = MarketDynamics or {}
 MarketDynamics.__index = MarketDynamics
 
 function MarketDynamics.new(modDir, modName)

--- a/src/MarketEngine.lua
+++ b/src/MarketEngine.lua
@@ -25,7 +25,7 @@
 --
 -- Author: tison (dev-1)
 
-MarketEngine = {}
+MarketEngine = MarketEngine or {}
 MarketEngine.__index = MarketEngine
 
 -- Update intervals (ms of in-game time)

--- a/src/MarketSerializer.lua
+++ b/src/MarketSerializer.lua
@@ -5,7 +5,7 @@
 --
 -- Author: tison (dev-1)
 
-MarketSerializer = {}
+MarketSerializer = MarketSerializer or {}
 
 local SAVE_PATH_TEMPLATE = "%sFS25_MarketDynamics.xml"
 

--- a/src/OrganicPremiumBridge.lua
+++ b/src/OrganicPremiumBridge.lua
@@ -23,7 +23,7 @@
 --   Failure is silent by contract: a throwing or non-positive return is skipped.
 -- =========================================================
 
-OrganicPremiumBridge = {}
+OrganicPremiumBridge = OrganicPremiumBridge or {}
 
 OrganicPremiumBridge.MODIFIER_NAME = "OrganicPremium"
 

--- a/src/RWEIntegration.lua
+++ b/src/RWEIntegration.lua
@@ -6,7 +6,7 @@
 -- CropStress detection: g_currentMission.cropStressManager (set by CS's Mission00.load hook).
 -- Pattern mirrors BCIntegration/UPIntegration — detected once in onMissionLoaded, then polled.
 
-MDMExternalIntegration = {}
+MDMExternalIntegration = MDMExternalIntegration or {}
 MDMExternalIntegration.__index = MDMExternalIntegration
 
 -- RWE event id → price multiplier applied to all tracked fill types.

--- a/src/ReleaseGate.lua
+++ b/src/ReleaseGate.lua
@@ -15,7 +15,7 @@
 -- system for a stable release is a deliberate act, never a default.
 -- =========================================================
 
-ReleaseGate = {}
+ReleaseGate = ReleaseGate or {}
 
 -- The certified experimental (LOCKED) set. Each entry: [systemId] = { name, status }.
 -- `status` is a SHORT player-facing note on what is not working or implemented yet.

--- a/src/UPIntegration.lua
+++ b/src/UPIntegration.lua
@@ -13,7 +13,7 @@
 --
 -- Author: tison (dev-1)
 
-UPIntegration = {}
+UPIntegration = UPIntegration or {}
 
 -- ---------------------------------------------------------------------------
 -- Config

--- a/src/WorldEventSystem.lua
+++ b/src/WorldEventSystem.lua
@@ -26,7 +26,7 @@
 --
 -- Author: tison (dev-1)
 
-WorldEventSystem = {}
+WorldEventSystem = WorldEventSystem or {}
 WorldEventSystem.__index = WorldEventSystem
 
 local CHECK_INTERVAL_MS = 5 * 60 * 1000   -- check for new events every 5 in-game minutes

--- a/src/events/MDMContractRequestEvent.lua
+++ b/src/events/MDMContractRequestEvent.lua
@@ -1,7 +1,7 @@
 -- MDMContractRequestEvent.lua
 -- Client-to-Server network event for contract actions (Create, Complete, Cancel, Delete).
 
-MDMContractRequestEvent = {}
+MDMContractRequestEvent = MDMContractRequestEvent or {}
 local MDMContractRequestEvent_mt = Class(MDMContractRequestEvent, Event)
 InitEventClass(MDMContractRequestEvent, "MDMContractRequestEvent")
 

--- a/src/events/MDMContractSyncEvent.lua
+++ b/src/events/MDMContractSyncEvent.lua
@@ -1,7 +1,7 @@
 -- MDMContractSyncEvent.lua
 -- Server-to-Client network event for syncing contract state.
 
-MDMContractSyncEvent = {}
+MDMContractSyncEvent = MDMContractSyncEvent or {}
 local MDMContractSyncEvent_mt = Class(MDMContractSyncEvent, Event)
 InitEventClass(MDMContractSyncEvent, "MDMContractSyncEvent")
 

--- a/src/events/MDMContractSyncRequestEvent.lua
+++ b/src/events/MDMContractSyncRequestEvent.lua
@@ -1,7 +1,7 @@
 -- MDMContractSyncRequestEvent.lua
 -- Client-to-Server network event. A client sends this upon joining to request a full contract sync.
 
-MDMContractSyncRequestEvent = {}
+MDMContractSyncRequestEvent = MDMContractSyncRequestEvent or {}
 local MDMContractSyncRequestEvent_mt = Class(MDMContractSyncRequestEvent, Event)
 InitEventClass(MDMContractSyncRequestEvent, "MDMContractSyncRequestEvent")
 

--- a/src/events/MDMMarketSyncEvent.lua
+++ b/src/events/MDMMarketSyncEvent.lua
@@ -1,7 +1,7 @@
 -- MDMMarketSyncEvent.lua
 -- Syncs prices and active world events from server to clients.
 
-MDMMarketSyncEvent = {}
+MDMMarketSyncEvent = MDMMarketSyncEvent or {}
 local MDMMarketSyncEvent_mt = Class(MDMMarketSyncEvent, Event)
 InitEventClass(MDMMarketSyncEvent, "MDMMarketSyncEvent")
 

--- a/src/events/MDMSettingsSyncEvent.lua
+++ b/src/events/MDMSettingsSyncEvent.lua
@@ -1,7 +1,7 @@
 -- MDMSettingsSyncEvent.lua
 -- Network event for syncing Market Dynamics settings between server and clients.
 
-MDMSettingsSyncEvent = {}
+MDMSettingsSyncEvent = MDMSettingsSyncEvent or {}
 local MDMSettingsSyncEvent_mt = Class(MDMSettingsSyncEvent, Event)
 InitEventClass(MDMSettingsSyncEvent, "MDMSettingsSyncEvent")
 

--- a/src/gui/MDMBrowseFillTypesDialog.lua
+++ b/src/gui/MDMBrowseFillTypesDialog.lua
@@ -3,7 +3,7 @@
 -- Opened from MDMEventFillTypeDialog footer.
 -- Includes a real-time search/filter input for servers with many fill types.
 
-MDMBrowseFillTypesDialog = {}
+MDMBrowseFillTypesDialog = MDMBrowseFillTypesDialog or {}
 local MDMBrowseFillTypesDialog_mt = Class(MDMBrowseFillTypesDialog, MessageDialog)
 
 function MDMBrowseFillTypesDialog.new(target, custom_mt)

--- a/src/gui/MDMContractAdminDialog.lua
+++ b/src/gui/MDMContractAdminDialog.lua
@@ -8,7 +8,7 @@
 --   onCancel   = function(contractId)  called after admin cancel/remove,
 -- }
 
-MDMContractAdminDialog = {}
+MDMContractAdminDialog = MDMContractAdminDialog or {}
 local MDMContractAdminDialog_mt = Class(MDMContractAdminDialog, MessageDialog)
 
 -- -----------------------------------------------------------------------

--- a/src/gui/MDMContractDialog.lua
+++ b/src/gui/MDMContractDialog.lua
@@ -12,7 +12,7 @@
 -- causes a layout stack overflow during showDialog. Crop selection happens in
 -- the main MarketScreen price list; the dialog operates on the selected crop.
 
-MDMContractDialog = {}
+MDMContractDialog = MDMContractDialog or {}
 local MDMContractDialog_mt = Class(MDMContractDialog, MessageDialog)
 
 -- -----------------------------------------------------------------------

--- a/src/gui/MDMCustomInputDialog.lua
+++ b/src/gui/MDMCustomInputDialog.lua
@@ -8,7 +8,7 @@
 --   onConfirmed  = function(value)
 -- }
 
-MDMCustomInputDialog = {}
+MDMCustomInputDialog = MDMCustomInputDialog or {}
 local MDMCustomInputDialog_mt = Class(MDMCustomInputDialog, MessageDialog)
 
 function MDMCustomInputDialog.new(target, custom_mt)

--- a/src/gui/MDMDialogLoader.lua
+++ b/src/gui/MDMDialogLoader.lua
@@ -8,7 +8,7 @@
 --   MDMDialogLoader.show("MDMContractDialog", "setData", data)
 --   MDMDialogLoader.cleanup()   -- call on FSBaseMission.delete
 
-MDMDialogLoader = {}
+MDMDialogLoader = MDMDialogLoader or {}
 
 MDMDialogLoader._registry = {}   -- name -> { class, xmlPath, instance, loaded }
 MDMDialogLoader._modDir   = nil

--- a/src/gui/MDMEventFillTypeDialog.lua
+++ b/src/gui/MDMEventFillTypeDialog.lua
@@ -10,7 +10,7 @@
 --
 -- Opened by MDMEventSettingsDialog:_handleEdit(rowIndex).
 
-MDMEventFillTypeDialog = {}
+MDMEventFillTypeDialog = MDMEventFillTypeDialog or {}
 local MDMEventFillTypeDialog_mt = Class(MDMEventFillTypeDialog, MessageDialog)
 
 local MAX_ROWS = 8

--- a/src/gui/MDMEventSettingsDialog.lua
+++ b/src/gui/MDMEventSettingsDialog.lua
@@ -16,7 +16,7 @@
 --
 -- Opened by MDMMarketScreen:onEventSettingsClick() from the Events tab.
 
-MDMEventSettingsDialog = {}
+MDMEventSettingsDialog = MDMEventSettingsDialog or {}
 local MDMEventSettingsDialog_mt = Class(MDMEventSettingsDialog, MessageDialog)
 
 local MAX_EVENT_ROWS = 10

--- a/src/gui/MarketScreen.lua
+++ b/src/gui/MarketScreen.lua
@@ -1,4 +1,4 @@
-MDMMarketScreen = {}
+MDMMarketScreen = MDMMarketScreen or {}
 
 MDMMarketScreen.CLASS_NAME = "MDMMarketScreen"
 MDMMarketScreen.MENU_PAGE_NAME = "menuMarketDynamics"
@@ -196,7 +196,7 @@ function MDMMarketScreen.show()
         -- Lazy deep load: with the RF Esc door hosting, the deep screen may never have
         -- been built, so Open full Market silently did nothing (eyes-on FAIL 2026-08-07).
         -- Build it on first use instead of bailing.
-        local modDir = MDMMarketScreen._modDir or g_currentModDirectory
+        local modDir = MDMMarketScreen._modDir or (MarketDynamicsModDirectory or g_currentModDirectory)
         if modDir ~= nil then
             MDMLog.info("MarketScreen.show: deep screen missing, loading on demand")
             pcall(MDMMarketScreen._loadDeepScreenOnly, modDir)
@@ -1256,7 +1256,7 @@ end
 -- Wired at source() time. MarketScreen manages its own registration.
 -- ---------------------------------------------------------------------------
 
-local _modDir = g_currentModDirectory
+local _modDir = (MarketDynamicsModDirectory or g_currentModDirectory)
 local _pendingRegistration = false
 local _pendingModDir = nil
 

--- a/src/gui/MarketScreenGraph.lua
+++ b/src/gui/MarketScreenGraph.lua
@@ -1,4 +1,4 @@
-MDMMarketScreenGraph = {}
+MDMMarketScreenGraph = MDMMarketScreenGraph or {}
 
 -- ---------------------------------------------------------------------------
 -- Constants

--- a/src/gui/MdRfPdaGuest.lua
+++ b/src/gui/MdRfPdaGuest.lua
@@ -9,10 +9,10 @@
 -- HARD VETO: never reintroduce addPageTab + raw stand-down product path.
 -- =========================================================
 
-MdRfPdaGuest = {}
+MdRfPdaGuest = MdRfPdaGuest or {}
 
-local MOD_DIR = g_currentModDirectory
-local MD_RF_MOD_NAME = g_currentModName
+local MOD_DIR = (MarketDynamicsModDirectory or g_currentModDirectory)
+local MD_RF_MOD_NAME = (MarketDynamicsModName or g_currentModName)
 local PANEL_ID = "marketDynamics"
 local PANEL_ORDER = 40
 local MAX_EVENT_ROWS = 6

--- a/src/gui/RfEscBootstrap.lua
+++ b/src/gui/RfEscBootstrap.lua
@@ -5,7 +5,7 @@
 -- No Soil privilege; no rfPdaHost. Option B equal-bootstrap path.
 -- =========================================================
 
-RfEscBootstrap = {}
+RfEscBootstrap = RfEscBootstrap or {}
 
 local PAGE_NAME = "menuRealisticFarming"
 local CLASS_NAME = "RfPdaMenuPage"
@@ -154,7 +154,7 @@ local function addIngameMenuPage(frame, pageName, iconPath, uvs, position, predi
 end
 
 --- Ensure shared Esc door exists. Idempotent: skip create if already present.
----@param modDir string g_currentModDirectory of the calling joiner
+---@param modDir string (MarketDynamicsModDirectory or g_currentModDirectory) of the calling joiner
 ---@param opts table|nil { profilesXml?, iconPath?, uvs? }
 ---@return boolean true if door exists after call
 function RfEscBootstrap.ensureDoor(modDir, opts)

--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -9,7 +9,7 @@
 -- lottery is NOT the product default.
 -- =========================================================
 
-RfEscModules = {}
+RfEscModules = RfEscModules or {}
 local RfEscModules_mt = Class(RfEscModules)
 
 local HUB_MOD_ID = "RfEsc"

--- a/src/gui/RfEscUiDebugger.lua
+++ b/src/gui/RfEscUiDebugger.lua
@@ -12,7 +12,7 @@
 -- Singleton: only one mod installs (prefer Soil; else first).
 -- =========================================================
 
-RfEscUiDebugger = {}
+RfEscUiDebugger = RfEscUiDebugger or {}
 
 local PAGE_NAME = "menuRealisticFarming"
 local CLASS_NAME = "RfPdaMenuPage"
@@ -65,8 +65,8 @@ local function _getSoilModDirectory()
             return d
         end
     end
-    if g_currentModName == SOIL_MOD_NAME and g_currentModDirectory ~= nil then
-        return g_currentModDirectory
+    if (MarketDynamicsModName or g_currentModName) == SOIL_MOD_NAME and (MarketDynamicsModDirectory or g_currentModDirectory) ~= nil then
+        return (MarketDynamicsModDirectory or g_currentModDirectory)
     end
     if g_modManager ~= nil and type(g_modManager.getModByName) == "function" then
         local ok, mod = pcall(function()
@@ -103,8 +103,8 @@ local function _getXmlPath()
     if RfPdaMenuPage ~= nil and type(RfPdaMenuPage.getXmlFilename) == "function" then
         return RfPdaMenuPage.getXmlFilename()
     end
-    if g_currentModDirectory ~= nil then
-        return g_currentModDirectory .. "xml/gui/" .. CLASS_NAME .. ".xml"
+    if (MarketDynamicsModDirectory or g_currentModDirectory) ~= nil then
+        return (MarketDynamicsModDirectory or g_currentModDirectory) .. "xml/gui/" .. CLASS_NAME .. ".xml"
     end
     return nil
 end
@@ -133,7 +133,7 @@ local function _getProfilesXml()
     if fromSoil ~= nil then
         return fromSoil
     end
-    return _profilesCandidate(g_currentModDirectory)
+    return _profilesCandidate((MarketDynamicsModDirectory or g_currentModDirectory))
 end
 
 local function _captureActiveModuleId()
@@ -707,7 +707,7 @@ function RfEscUiDebugger.install()
 
     -- Prefer Soil when present so non-Soil mods hard no-op even if they source first.
     local soilDir = _getSoilModDirectory()
-    local myDir = g_currentModDirectory
+    local myDir = (MarketDynamicsModDirectory or g_currentModDirectory)
     if soilDir ~= nil and myDir ~= nil and _normDir(soilDir) ~= _normDir(myDir) then
         return
     end
@@ -719,7 +719,7 @@ function RfEscUiDebugger.install()
     end
     _listenerInstalled = true
     _markInstalledGlobally()
-    local owner = (g_currentModName ~= nil and g_currentModName) or "unknown"
+    local owner = ((MarketDynamicsModName or g_currentModName) ~= nil and (MarketDynamicsModName or g_currentModName)) or "unknown"
     _log("info", "installed by %s (F6 / rfEscReloadGui). Dev-only; frame-replace path; not Vera F1 substitute.", tostring(owner))
 end
 

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -13,8 +13,8 @@
 -- SoilPDAScreen coexists untouched.
 -- =========================================================
 
-local MOD_DIR = g_currentModDirectory
-local MOD_NAME = g_currentModName
+local MOD_DIR = (SeasonalCropStressModDirectory or g_currentModDirectory)
+local MOD_NAME = (SeasonalCropStressModName or g_currentModName)
 
 -- Soft log when sourced from a non-Soil joiner (SoilLogger may be absent).
 -- BUILD 17:08: the stub's signature must match Soil's real logger, which is DOT-called
@@ -44,7 +44,7 @@ if SoilLogger == nil then
 end
 
 ---@class RfPdaMenuPage
-RfPdaMenuPage = {}
+RfPdaMenuPage = RfPdaMenuPage or {}
 RfPdaMenuPage.CLASS_NAME = "RfPdaMenuPage"
 -- NO-HOST: shared Esc door name (not Soil-owned menuSoilFertilizer).
 RfPdaMenuPage.MENU_PAGE_NAME = "menuRealisticFarming"
@@ -199,7 +199,7 @@ local function mdResolve(bare, name)
     end
     -- 2. the named environment. Kept first among the fallbacks because it is the cheapest
     --    and correct in the common case, but NOT trusted alone - this hardcodes a mod name
-    --    the guest itself never hardcodes (it uses g_currentModName), so a rename or a
+    --    the guest itself never hardcodes (it uses (SeasonalCropStressModName or g_currentModName)), so a rename or a
     --    differently-named install slips straight past it. That is what produced
     --    "GATE graph=false" on the Dairy door.
     if g_modEnvironments ~= nil then
@@ -1632,8 +1632,20 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     -- exist and would never have hidden them.
     for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext" }) do
         local btn = self:getDescendantById(id)
-        if btn ~= nil and type(btn.setVisible) == "function" then
-            btn:setVisible(false)
+        if btn ~= nil then
+            btn.inputActionName = nil
+            btn.keyDisplayText = nil
+            btn.keyOverlay = nil
+            btn.hideKeyboardGlyph = true
+            btn.hasLoadedInputGlyph = false
+            btn.isKeyboardMode = false
+            btn.keyGlyphOffsetX = 0
+            btn.keyGlyphSize = { 0, 0 }
+            btn.iconSize = { 0, 0 }
+            btn.icon = {}
+            if type(btn.setVisible) == "function" then
+                btn:setVisible(false)
+            end
         end
     end
     -- Action bar rides the CS module only; the guest decides the two buttons.
@@ -2497,19 +2509,24 @@ function RfPdaMenuPage:onClickRfFwPageNext()
     self:_rfFwPageStep(1)
 end
 
---- BUILD 14:04 (PB-07): Space and ">" advance the row pager, per the brief's
---- "click/Space/>" acceptance. keyEvent walks children first via the superclass
---- (GuiElement.lua:772-784, children in reverse order, eventUsed carried), so a focused
---- control that consumes the key - including the pager Button itself activating on Space -
---- wins before this fires and nothing double-steps. Only an unclaimed press reaches the
---- step, and only a step that actually moved marks the event used; on every page without a
---- pageable guest _rfFwPageStep returns false immediately and the key passes through
---- untouched. unicode 32 is Space, 62 is ">", taken from the event's own unicode so the
---- layout that produced ">" does not matter.
+--- 2026-08-22 (Wizard): pager keys are now . / > for next and , / < for back
+--- (Space is retired - it collided with the engine's global button-activate and its
+--- glyph chip was what overlapped the labels; the buttons themselves now use the
+--- glyph-hidden RF_CsPivotBtn profile). keyEvent walks children first via the
+--- superclass (GuiElement.lua:772-784, children in reverse order, eventUsed carried),
+--- so a focused control that consumes the key wins before this fires and nothing
+--- double-steps. Only an unclaimed press reaches the step, and only a step that
+--- actually moved marks the event used; on every page without a pageable guest
+--- _rfFwPageStep returns false immediately and the key passes through untouched.
+--- unicode 46 is ".", 62 is ">", 44 is ",", 60 is "<" - taken from the event's own
+--- unicode so keyboard layout does not matter.
 function RfPdaMenuPage:keyEvent(unicode, sym, modifier, isDown, eventUsed)
     local used = RfPdaMenuPage:superClass().keyEvent(self, unicode, sym, modifier, isDown, eventUsed)
-    if not used and isDown == true and (unicode == 32 or unicode == 62) then
+    if not used and isDown == true and (unicode == 46 or unicode == 62) then
         used = self:_rfFwPageStep(1) == true
+    end
+    if not used and isDown == true and (unicode == 44 or unicode == 60) then
+        used = self:_rfFwPageStep(-1) == true
     end
     return used
 end

--- a/src/gui/SettingsUI.lua
+++ b/src/gui/SettingsUI.lua
@@ -3,10 +3,10 @@
 -- Pattern based on SoilSettingsPanel (FS25_SoilFertilizer).
 
 ---@class MDMSettingsPanel
-MDMSettingsPanel = {}
+MDMSettingsPanel = MDMSettingsPanel or {}
 local MDMSettingsPanel_mt = Class(MDMSettingsPanel)
 
-local MDM_MOD_NAME = g_currentModName
+local MDM_MOD_NAME = (MarketDynamicsModName or g_currentModName)
 
 -- ── i18n helper ───────────────────────────────────────────
 local function tr(key, fallback)

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -586,9 +586,16 @@
                                  re-enter the layout the way a list rebuild can.
                                  Parked on the rfFwTableTitle band, which every Table-mode guest
                                  already hides, so the pager collides with nothing that paints. -->
-                            <Button profile="buttonActivate" id="rfFwPagePrev" position="880px -8px" size="120px 24px"
+                            <!-- 2026-08-22 FAIL-FIX (live screenshot 17:11): bottom-right placement inside
+                                 the 1140x428 table frame was correct and is kept; the profile was not.
+                                 RF_CsPivotBtn inherits inputAction MENU_ACTIVATE from buttonActivate, so the
+                                 engine painted a SPACE key chip on BOTH buttons and each chip pushed its own
+                                 label out of its 120px box into the neighbour. RF_FwPagerBtn extends
+                                 fs25_wideButton instead - identical chrome, no inputAction, so no chip.
+                                 See rfEscProfiles.xml. Page keys: . / > next, , / < back. -->
+                            <Button profile="RF_FwPagerBtn" id="rfFwPagePrev" position="880px -396px" size="120px 24px"
                                     visible="false" text="" onClick="onClickRfFwPagePrev"/>
-                            <Button profile="buttonActivate" id="rfFwPageNext" position="1010px -8px" size="120px 24px"
+                            <Button profile="RF_FwPagerBtn" id="rfFwPageNext" position="1010px -396px" size="120px 24px"
                                     visible="false" text="" onClick="onClickRfFwPageNext"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -380,6 +380,29 @@
         <isTriggerableByGlobalAction value="false"/>
         <iconSize value="30px 30px"/>
     </Profile>
+
+    <!-- 2026-08-22 FAIL-FIX (live screenshot 17:11): the row pager must NOT inherit an
+         inputAction. RF_CsPivotBtn extends buttonActivate, and buttonActivate sets
+         inputAction MENU_ACTIVATE (base game guiProfiles.xml:2084-2087). The engine paints
+         that action's SPACE key chip on every button carrying it, which is what shoved each
+         label out of its own 120px box and into the next button ("< BACK" + the neighbouring
+         chip is what read as "BACKSPACE" on screen). hideKeyboardGlyph did NOT suppress it
+         here - it appears exactly once in the whole base-game profile set, on a disabled
+         gamepad-only selector - and isTriggerableByGlobalAction is not an engine property at
+         all (zero occurrences base game), so both were inert.
+         fs25_wideButton (guiProfiles.xml:2671) is buttonActivate's OWN base minus the
+         inputAction, so this profile is the same chrome with no key chip to draw. The mouse
+         click still works: it runs through onClick, which never needed the input action.
+         Page keys live in RfPdaMenuPage:keyEvent as . / > and , / < . -->
+    <Profile name="RF_FwPagerBtn" extends="fs25_wideButton" with="anchorTopLeft pivotTopLeft">
+        <size value="120px 24px"/>
+        <textSize value="13px"/>
+        <textBold value="true"/>
+        <textUpperCase value="false"/>
+        <fitToContent value="false"/>
+        <textAutoWidth value="false"/>
+        <textAlignment value="center"/>
+    </Profile>
     <Profile name="RF_ProductsRowsClip" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
         <size value="560px 160px"/>
         <clipChildren value="true"/>


### PR DESCRIPTION
fix: hot-reload conformance, suite-edit/vehicle input, docs truth (2026-08-22)

- entry/module latch: g_currentModDirectory/Name latched into module globals with g_modsDirectory fallback so live re-source cannot nil-crash
- hot-reload conformance: class tables declared X = X or {} so Ctrl+R reloads update live instances; raw g_currentModDirectory readers fall back to the latch
- RF PDA pager: glyph-free RF_CsPivotBtn buttons anchored bottom-right of the table frame; page keys . / > next and , / < back

Built zips are not part of this change. UTF-8 without BOM on all touched files.