### PR TITLE
fix: sync price history on MP join

### DIFF
--- a/src/MDMNetworkSyncBridge.lua
+++ b/src/MDMNetworkSyncBridge.lua
@@ -163,7 +163,8 @@ end
 -- ── State-sync serialization (server->client full snapshot) ───────────────────
 -- Flatten the whole syncable state into one typed array. Length-prefixed sub-lists so
 -- NetworkSync's flat, type-tagged array round-trips: contractCount, then 12 fields per
--- contract (mirroring MDMContractSyncEvent:writeContract); priceCount, then 2 per price;
+-- contract (mirroring MDMContractSyncEvent:writeContract); priceCount, then 3+2*histLen
+-- per price (index, volatilityFactor, histCount, then price+time pairs);
 -- eventCount, then 4 per active event.
 local function buildStateArray()
     local arr = {}
@@ -200,6 +201,12 @@ local function buildStateArray()
     for _, p in ipairs(prices) do
         arr[#arr + 1] = p.index or 0
         arr[#arr + 1] = p.volatilityFactor or 1
+        local hist = p.history or {}
+        arr[#arr + 1] = #hist
+        for _, h in ipairs(hist) do
+            arr[#arr + 1] = h.price or 0
+            arr[#arr + 1] = h.time or 0
+        end
     end
     arr[#arr + 1] = #events
     for _, e in ipairs(events) do
@@ -241,8 +248,16 @@ local function applyStateArray(arr)
     local pCount = tonumber(arr[i]) or 0; i = i + 1
     local prices = {}
     for _ = 1, pCount do
-        prices[#prices + 1] = { index = arr[i], volatilityFactor = arr[i + 1] }
-        i = i + 2
+        local pIndex = arr[i]
+        local pVol   = arr[i + 1]
+        local hCount = tonumber(arr[i + 2]) or 0
+        i = i + 3
+        local history = {}
+        for _ = 1, hCount do
+            history[#history + 1] = { price = arr[i], time = arr[i + 1] }
+            i = i + 2
+        end
+        prices[#prices + 1] = { index = pIndex, volatilityFactor = pVol, history = history }
     end
 
     local eCount = tonumber(arr[i]) or 0; i = i + 1

--- a/src/events/MDMMarketSyncEvent.lua
+++ b/src/events/MDMMarketSyncEvent.lua
@@ -9,14 +9,15 @@ function MDMMarketSyncEvent.emptyNew()
     return Event.new(MDMMarketSyncEvent_mt)
 end
 
-function MDMMarketSyncEvent.new(marketEngine, worldEvents)
+function MDMMarketSyncEvent.new(marketEngine, worldEvents, includeHistory)
     local self = MDMMarketSyncEvent.emptyNew()
     self.prices = {}
     if marketEngine then
         for index, entry in pairs(marketEngine.prices) do
             table.insert(self.prices, {
                 index = index,
-                volatilityFactor = entry.volatilityFactor
+                volatilityFactor = entry.volatilityFactor,
+                history = includeHistory and entry.history or {},
             })
         end
     end
@@ -51,7 +52,7 @@ end
 
 function MDMMarketSyncEvent.sendToClient(connection)
     if g_server ~= nil and connection ~= nil and g_MarketDynamics then
-        connection:sendEvent(MDMMarketSyncEvent.new(g_MarketDynamics.marketEngine, g_MarketDynamics.worldEvents))
+        connection:sendEvent(MDMMarketSyncEvent.new(g_MarketDynamics.marketEngine, g_MarketDynamics.worldEvents, true))
     end
 end
 
@@ -61,6 +62,12 @@ function MDMMarketSyncEvent:writeStream(streamId, connection)
     for _, p in ipairs(self.prices) do
         streamWriteInt32(streamId, p.index)
         streamWriteFloat32(streamId, p.volatilityFactor)
+        local hist = p.history or {}
+        streamWriteInt32(streamId, #hist)
+        for _, h in ipairs(hist) do
+            streamWriteFloat32(streamId, h.price or 0)
+            streamWriteFloat32(streamId, h.time or 0)
+        end
     end
 
     -- Write active events
@@ -77,9 +84,20 @@ function MDMMarketSyncEvent:readStream(streamId, connection)
     self.prices = {}
     local numPrices = streamReadInt32(streamId)
     for i = 1, numPrices do
+        local index = streamReadInt32(streamId)
+        local volatilityFactor = streamReadFloat32(streamId)
+        local numHist = streamReadInt32(streamId)
+        local history = {}
+        for j = 1, numHist do
+            history[j] = {
+                price = streamReadFloat32(streamId),
+                time  = streamReadFloat32(streamId),
+            }
+        end
         table.insert(self.prices, {
-            index = streamReadInt32(streamId),
-            volatilityFactor = streamReadFloat32(streamId)
+            index = index,
+            volatilityFactor = volatilityFactor,
+            history = history,
         })
     end
 
@@ -99,7 +117,7 @@ end
 -- Apply market prices + active world events to the local client. Extracted from :run so
 -- the NetworkSync bridge can reuse the EXACT same apply path (prices, event lifecycle,
 -- notifications, UI refresh) instead of re-implementing it. `prices` = array of
--- {index, volatilityFactor}; `activeEvents` = array of {id, endsAt, intensity, extraData}.
+-- {index, volatilityFactor, history?}; `activeEvents` = array of {id, endsAt, intensity, extraData}.
 function MDMMarketSyncEvent.applyState(prices, activeEvents)
     if not g_MarketDynamics then return end
 
@@ -108,6 +126,12 @@ function MDMMarketSyncEvent.applyState(prices, activeEvents)
             local entry = g_MarketDynamics.marketEngine.prices[p.index]
             if entry then
                 entry.volatilityFactor = p.volatilityFactor
+                if p.history and #p.history > 0 then
+                    entry.history = p.history
+                    if MDMMarketScreenGraph ~= nil and type(MDMMarketScreenGraph.seedFromHistory) == "function" then
+                        MDMMarketScreenGraph.seedFromHistory(p.index, p.history)
+                    end
+                end
                 g_MarketDynamics.marketEngine:_recalculate(p.index)
             end
         end


### PR DESCRIPTION
## Summary
- Market graph started empty after rejoining an MP server because `MDMMarketSyncEvent` only synced `volatilityFactor`, not the daily price history array
- Now both the own-event path (`sendToClient`) and the NetworkSync bridge (`buildStateArray`/`applyStateArray`) include history in the join snapshot
- Periodic broadcasts (`sendToClients`) stay lightweight -- history is only sent on the join path
- `applyState` restores history into `MarketEngine` and seeds the graph ring buffer via `seedFromHistory`

## Test plan
- [ ] Host an MP server, let prices run for a few in-game days so history builds up
- [ ] Have a client join -- verify the graph shows the server's price history immediately
- [ ] Client disconnects and rejoins -- verify the graph is restored, not empty
- [ ] Verify periodic price updates still work (no regression in broadcast path)
- [ ] Test with NetworkSync installed (bridge path) and without (own-event path)

Fixes: nitro's report (Discord testing wave 2026-08-23) -- "After rejoining the server the market graph history is gone and starts anew"