### PR TITLE
Hide leftover Esc eight-row hairlines

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="106">
     <author>TisonK &amp; LeGrizzly</author>
-    <version>1.3.1.32</version>
+    <version>1.3.1.35</version>
     <title>
         <en>Market Dynamics</en>
     </title>
@@ -42,6 +42,7 @@
         <sourceFile filename="src/gui/RfPdaMenuPage.lua" />
         <sourceFile filename="src/gui/RfEscBootstrap.lua" />
         <sourceFile filename="src/gui/RfEscUiDebugger.lua" />
+        <sourceFile filename="src/gui/MdGuideDialog.lua" />
         <sourceFile filename="src/gui/MdRfPdaGuest.lua" />
         <sourceFile filename="src/events/MDMContractRequestEvent.lua" />
         <sourceFile filename="src/events/MDMContractSyncEvent.lua" />

--- a/src/gui/MdGuideDialog.lua
+++ b/src/gui/MdGuideDialog.lua
@@ -1,0 +1,378 @@
+-- =========================================================
+-- Market Field Guide - Field Guide
+-- =========================================================
+-- BUILD 19:15 (George CLOSED DESIGN 18:55 item 5): every Realistic Farming Esc page gets its own
+-- guide, in its own mod, opened from the shared Help footer through this guest's onOpenHelp. The
+-- chrome is SoilGuideDialog's so all of them read as one family; only the words differ.
+-- Rows are { t = "H" | "B" | "S" | "COL", v = "text" }: header, body, spacer, column break.
+-- =========================================================
+
+---@class MdGuideDialog
+MdGuideDialog = MdGuideDialog or {}
+local MdGuideDialog_mt = Class(MdGuideDialog, ScreenElement)
+
+local GUIDE_MOD_DIR = (MarketDynamicsModDirectory or g_currentModDirectory)
+
+MdGuideDialog.INSTANCE = nil
+MdGuideDialog.GUI_NAME = "MdGuideDialog"
+
+MdGuideDialog.SUBTITLES = {
+    "Overview - what the mod does and where to find it",
+    "How Prices Move - the price engine and the graph",
+    "Market Events - what can fire and what it does",
+    "Futures Contracts - opening, delivering, cancelling",
+    "Settings and FAQ - every setting and common fixes",
+}
+
+MdGuideDialog.PAGE1 = {
+    { t="H", v="WHAT THIS MOD DOES" },
+    { t="B", v="Crop prices no longer sit still. Every good" },
+    { t="B", v="the game buys gets a live price that drifts" },
+    { t="B", v="through the day and shifts again each day." },
+    { t="B", v="World events can push whole groups of goods" },
+    { t="B", v="up or down for as long as they last." },
+    { t="B", v="You are paid the live price when you sell at" },
+    { t="B", v="a selling station." },
+    { t="B", v="Futures contracts let you lock today's price" },
+    { t="B", v="and deliver the crop later." },
+    { t="S", v=" " },
+    { t="H", v="FINDING THE PAGE" },
+    { t="B", v="Open the pause menu and choose the Realistic" },
+    { t="B", v="Farming tab." },
+    { t="B", v="At the top of that page, use the module" },
+    { t="B", v="picker to select Market Dynamics." },
+    { t="B", v="A second picker underneath gives three" },
+    { t="B", v="pages: Prices, Events and Contracts." },
+    { t="S", v=" " },
+    { t="COL", v="" },
+    { t="H", v="THE TABLE AT THE TOP" },
+    { t="B", v="All three pages share one table of tracked" },
+    { t="B", v="goods, with Crop, Price and Change columns." },
+    { t="B", v="Click a row to pick that good. Your pick" },
+    { t="B", v="drives the graph and the new contract card." },
+    { t="B", v="The page refreshes itself every couple of" },
+    { t="B", v="seconds, so the numbers stay current." },
+    { t="S", v=" " },
+    { t="H", v="WHAT EACH PAGE IS FOR" },
+    { t="B", v="Prices: the good you picked, its price and" },
+    { t="B", v="a trend graph under the table." },
+    { t="B", v="Events: what is hitting the market now." },
+    { t="B", v="Contracts: your open deals, and a card for" },
+    { t="B", v="opening a new one." },
+    { t="S", v=" " },
+    { t="H", v="ANOTHER WAY IN" },
+    { t="B", v="A larger Market screen opens on its own key," },
+    { t="B", v="by default Right Shift and 5. It shows the" },
+    { t="B", v="same three tabs with more detail and a New" },
+    { t="B", v="Contract button. The key can be rebound" },
+    { t="B", v="under Options, Controls." },
+}
+
+MdGuideDialog.PAGE2 = {
+    { t="H", v="HOW A PRICE IS BUILT" },
+    { t="B", v="Each good starts from the price the game" },
+    { t="B", v="itself would pay. That base is refreshed once" },
+    { t="B", v="a day, so seasonal swings still count." },
+    { t="B", v="On top of the base sits a drift factor that" },
+    { t="B", v="wanders up and down." },
+    { t="B", v="Anything an event is doing multiplies on top" },
+    { t="B", v="of that." },
+    { t="B", v="The result never falls below half the base" },
+    { t="B", v="price and never rises above double it." },
+    { t="S", v=" " },
+    { t="H", v="HOW OFTEN IT MOVES" },
+    { t="B", v="A small nudge lands every in-game minute." },
+    { t="B", v="A larger shift lands once per in-game day," },
+    { t="B", v="and that day's price is kept for the graph." },
+    { t="B", v="Drift is always pulled gently back toward" },
+    { t="B", v="the base, so no run lasts forever." },
+    { t="S", v=" " },
+    { t="COL", v="" },
+    { t="H", v="READING THE TABLE" },
+    { t="B", v="Prices are written per 1,000 litres." },
+    { t="B", v="Animals are priced per head instead." },
+    { t="B", v="Change is the gap between the live price and" },
+    { t="B", v="the base price, as a percentage." },
+    { t="B", v="Under the table the Prices page names your" },
+    { t="B", v="picked good, its price and change, and adds" },
+    { t="B", v="a plain reading such as near base, softly up," },
+    { t="B", v="up sharply or soft against base." },
+    { t="S", v=" " },
+    { t="H", v="THE PRICE TREND GRAPH" },
+    { t="B", v="The graph draws under the table on the" },
+    { t="B", v="Prices page, for the good you picked." },
+    { t="B", v="With nothing picked it asks you to pick one." },
+    { t="B", v="A good with too little history says so, and" },
+    { t="B", v="the line appears as prices build up across" },
+    { t="B", v="in-game days." },
+    { t="B", v="The line is fed by samples taken while you" },
+    { t="B", v="play, plus the daily prices the mod keeps." },
+}
+
+MdGuideDialog.PAGE3 = {
+    { t="H", v="WHAT A MARKET EVENT IS" },
+    { t="B", v="Now and then the market throws an event." },
+    { t="B", v="While it runs it pushes the price of the" },
+    { t="B", v="goods it touches up or down." },
+    { t="B", v="Events start on their own, run for a while," },
+    { t="B", v="then expire by themselves." },
+    { t="B", v="The mod rolls for a new event on a regular" },
+    { t="B", v="check, and each event has a cooling-off gap" },
+    { t="B", v="so the same one cannot fire back to back." },
+    { t="S", v=" " },
+    { t="H", v="THE EVENTS THAT CAN FIRE" },
+    { t="B", v="Regional Drought" },
+    { t="B", v="Bumper Harvest" },
+    { t="B", v="Trade Disruption" },
+    { t="B", v="Geopolitical Crisis" },
+    { t="B", v="Biofuel Initiative" },
+    { t="B", v="Livestock Feed Boom" },
+    { t="B", v="Root Crop Blight" },
+    { t="B", v="Cold Snap" },
+    { t="B", v="Financial Panic" },
+    { t="B", v="Protein Premium Surge" },
+    { t="S", v=" " },
+    { t="COL", v="" },
+    { t="H", v="THE EVENTS PAGE" },
+    { t="B", v="The left card lists what is running now," },
+    { t="B", v="under Event, Intensity and Time left." },
+    { t="B", v="Intensity reads Mild, Moderate or Severe." },
+    { t="B", v="Time left counts down to the end of it." },
+    { t="B", v="Up to eight events are listed. If more are" },
+    { t="B", v="running, a line says how many are hidden." },
+    { t="B", v="When the market is calm the card simply says" },
+    { t="B", v="there are no active market events." },
+    { t="S", v=" " },
+    { t="H", v="THE EVENT SETTINGS CARD" },
+    { t="B", v="The right card is a read-only summary:" },
+    { t="B", v="whether events are switched on, how often" },
+    { t="B", v="they are set to happen, how many events are" },
+    { t="B", v="enabled out of the total, and which ones are" },
+    { t="B", v="running right now." },
+    { t="B", v="The Event settings button opens the full" },
+    { t="B", v="dialog, with the master switch, frequency," },
+    { t="B", v="per-event rules and the goods they hit." },
+    { t="B", v="Only the server host or an admin can open" },
+    { t="B", v="it. Everyone else sees a host only note." },
+}
+
+MdGuideDialog.PAGE4 = {
+    { t="H", v="WHAT A FUTURES CONTRACT IS" },
+    { t="B", v="You promise a number of litres of one good" },
+    { t="B", v="by a deadline, at the price locked when you" },
+    { t="B", v="sign." },
+    { t="B", v="You are still paid the live market price at" },
+    { t="B", v="the station as you deliver. The contract" },
+    { t="B", v="settles the difference at the end, so the" },
+    { t="B", v="litres you promised are worth exactly the" },
+    { t="B", v="locked price, no more and no less." },
+    { t="S", v=" " },
+    { t="H", v="OPENING ONE" },
+    { t="B", v="Go to the Contracts page and pick a good in" },
+    { t="B", v="the table at the top first." },
+    { t="B", v="The New contract card on the right then" },
+    { t="B", v="shows that good and the price it would lock." },
+    { t="B", v="Choose a quantity: 500, 1,000, 5,000," },
+    { t="B", v="10,000, 25,000 or 50,000 litres." },
+    { t="B", v="Choose a delivery window: 30, 60, 90 or" },
+    { t="B", v="120 days." },
+    { t="B", v="Press Confirm contract. The deal appears on" },
+    { t="B", v="the left once the server accepts it." },
+    { t="S", v=" " },
+    { t="COL", v="" },
+    { t="H", v="YOUR OPEN DEALS" },
+    { t="B", v="The left card lists up to five deals, with" },
+    { t="B", v="Crop, Quantity, Locked price and Status." },
+    { t="B", v="Status reads Active, At risk, Fulfilled or" },
+    { t="B", v="Failed. At risk means the deadline is close" },
+    { t="B", v="and less than half has been delivered." },
+    { t="B", v="To deliver, just sell that good at any" },
+    { t="B", v="selling station. Litres count against your" },
+    { t="B", v="matching deals on their own." },
+    { t="S", v=" " },
+    { t="H", v="CANCELLING A DEAL" },
+    { t="B", v="Click a deal in the list to pick it, then" },
+    { t="B", v="press Cancel deal." },
+    { t="B", v="Cancelling defaults the deal there and then." },
+    { t="B", v="What you already delivered settles at the" },
+    { t="B", v="locked price, and the leave-early fee is" },
+    { t="B", v="charged on every litre you did not deliver." },
+    { t="B", v="It can end as a charge rather than a payment," },
+    { t="B", v="so only cancel when you mean it." },
+}
+
+MdGuideDialog.PAGE5 = {
+    { t="H", v="OPENING THE SETTINGS PANEL" },
+    { t="B", v="The settings panel has its own Controls" },
+    { t="B", v="action, by default Right Shift and the slash" },
+    { t="B", v="key. Rebind it under Options, Controls." },
+    { t="B", v="It will not open while another menu or" },
+    { t="B", v="dialog is already on screen." },
+    { t="B", v="The panel opens on two cards, Market Engines" },
+    { t="B", v="and Simulation. Click a card, then click a" },
+    { t="B", v="value to change it." },
+    { t="B", v="A bar at the bottom says whether you count" },
+    { t="B", v="as an admin, and single or multiplayer." },
+    { t="S", v=" " },
+    { t="H", v="MARKET ENGINES" },
+    { t="B", v="Dynamic Prices turns all price movement on" },
+    { t="B", v="or off, giving the game's own prices back." },
+    { t="B", v="Real Days Delivery makes contract deadlines" },
+    { t="B", v="follow real time instead of in-game days." },
+    { t="B", v="Default Penalty sets the fee charged on" },
+    { t="B", v="undelivered litres: 8, 15 or 25 percent." },
+    { t="S", v=" " },
+    { t="COL", v="" },
+    { t="H", v="SIMULATION" },
+    { t="B", v="World Events allows or blocks events." },
+    { t="B", v="Prices still drift when events are off." },
+    { t="B", v="Event Frequency sets Rare, Normal or Frequent." },
+    { t="B", v="Event Notifications announces a new event." },
+    { t="B", v="Compact Event Banner turns that into a small" },
+    { t="B", v="corner banner instead of a pop-up." },
+    { t="B", v="Contract HUD shows a progress tracker for" },
+    { t="B", v="active contracts. Drag it with the left" },
+    { t="B", v="mouse button; the wheel resizes it." },
+    { t="B", v="Debug Mode and Experimental Systems are for" },
+    { t="B", v="testing. Leave them off for normal play." },
+    { t="S", v=" " },
+    { t="H", v="COMMON QUESTIONS" },
+    { t="B", v="Prices look frozen. Check Dynamic Prices is" },
+    { t="B", v="on, then give it an in-game minute." },
+    { t="B", v="The graph is empty. Pick a good, then let a" },
+    { t="B", v="few in-game days pass." },
+    { t="B", v="Event settings are host or admin only." },
+    { t="B", v="The new contract card is grey. Either no" },
+    { t="B", v="good is picked, or the Futures Mission" },
+    { t="B", v="add-on is installed and owns contracts." },
+    { t="B", v="Only crop sold after you sign counts." },
+}
+
+MdGuideDialog.PAGE_CONTENT = { MdGuideDialog.PAGE1, MdGuideDialog.PAGE2, MdGuideDialog.PAGE3, MdGuideDialog.PAGE4, MdGuideDialog.PAGE5 }
+
+-- -- Constructor ------------------------------------------
+
+function MdGuideDialog.new(target, customMt)
+    local self = ScreenElement.new(target, customMt or MdGuideDialog_mt)
+    self._contentLineEls = {}
+    self._currentPage = 1
+    return self
+end
+
+--- Loads the dialog into g_gui once. Safe to call twice, and safe to call when some other path has
+--- already registered the same name.
+function MdGuideDialog.register(modDirectory)
+    if g_gui == nil then return end
+    if g_gui.guis ~= nil and g_gui.guis[MdGuideDialog.GUI_NAME] ~= nil then return end
+    if modDirectory ~= nil then GUIDE_MOD_DIR = modDirectory end
+    if GUIDE_MOD_DIR == nil then return end
+    MdGuideDialog.INSTANCE = MdGuideDialog.new()
+    local ok, err = pcall(function()
+        g_gui:loadGui(GUIDE_MOD_DIR .. "xml/gui/MdGuideDialog.xml", MdGuideDialog.GUI_NAME, MdGuideDialog.INSTANCE)
+    end)
+    if not ok then
+        print("[MDM] MdGuideDialog: loadGui failed: " .. tostring(err))
+        MdGuideDialog.INSTANCE = nil
+    end
+end
+
+function MdGuideDialog.show()
+    if g_gui == nil then return end
+    local loaded = g_gui.guis ~= nil and g_gui.guis[MdGuideDialog.GUI_NAME] ~= nil
+    if not loaded then
+        MdGuideDialog.register(GUIDE_MOD_DIR)
+        loaded = g_gui.guis ~= nil and g_gui.guis[MdGuideDialog.GUI_NAME] ~= nil
+    end
+    if not loaded then return end
+    g_gui:showDialog(MdGuideDialog.GUI_NAME)
+end
+
+-- -- Lifecycle --------------------------------------------
+
+function MdGuideDialog:onGuiSetupFinished()
+    MdGuideDialog:superClass().onGuiSetupFinished(self)
+    self._elCol1 = self:getDescendantById("mdGuide_col1")
+    self._elCol2 = self:getDescendantById("mdGuide_col2")
+    self._elSubtitle = self:getDescendantById("mdGuide_subtitle")
+end
+
+function MdGuideDialog:onOpen()
+    MdGuideDialog:superClass().onOpen(self)
+    self._currentPage = 1
+    self:_selectPage(1)
+end
+
+function MdGuideDialog:onClose()
+    MdGuideDialog:superClass().onClose(self)
+    self:_clearContent()
+    self._currentPage = 1
+end
+
+-- -- Tabs -------------------------------------------------
+
+function MdGuideDialog:onClickTab1() self:_selectPage(1) end
+function MdGuideDialog:onClickTab2() self:_selectPage(2) end
+function MdGuideDialog:onClickTab3() self:_selectPage(3) end
+function MdGuideDialog:onClickTab4() self:_selectPage(4) end
+function MdGuideDialog:onClickTab5() self:_selectPage(5) end
+
+function MdGuideDialog:_selectPage(pageNum)
+    if self._currentPage == pageNum and #self._contentLineEls > 0 then return end
+    self:_clearContent()
+    self._currentPage = pageNum
+    if self._elSubtitle ~= nil then
+        self._elSubtitle:setText(MdGuideDialog.SUBTITLES[pageNum] or "")
+    end
+    self:_buildContent(pageNum)
+end
+
+-- -- Content ----------------------------------------------
+
+function MdGuideDialog:_buildContent(pageNum)
+    local profileH = g_gui:getProfile("mdGuide_colHeader")
+    local profileB = g_gui:getProfile("mdGuide_colBody")
+    local profileS = g_gui:getProfile("mdGuide_colSpacer")
+    if not profileH or not profileB then
+        print("[MDM] MdGuideDialog: column profiles not found")
+        return
+    end
+    local content = MdGuideDialog.PAGE_CONTENT[pageNum]
+    if content == nil then return end
+    local currentBox = self._elCol1
+    for _, row in ipairs(content) do
+        if row.t == "COL" then
+            if self._elCol1 ~= nil then self._elCol1:invalidateLayout() end
+            currentBox = self._elCol2
+        elseif currentBox ~= nil then
+            local profile = (row.t == "H") and profileH
+                         or (row.t == "S") and profileS
+                         or profileB
+            if profile ~= nil then
+                local el = TextElement.new()
+                el:loadProfile(profile, true)
+                el:setText(row.v or "")
+                currentBox:addElement(el)
+                el:onGuiSetupFinished()
+                table.insert(self._contentLineEls, { box = currentBox, el = el })
+            end
+        end
+    end
+    if self._elCol2 ~= nil then self._elCol2:invalidateLayout() end
+end
+
+function MdGuideDialog:_clearContent()
+    for _, entry in ipairs(self._contentLineEls or {}) do
+        if entry.box ~= nil then
+            entry.box:removeElement(entry.el)
+        end
+    end
+    self._contentLineEls = {}
+    if self._elCol1 ~= nil then self._elCol1:invalidateLayout() end
+    if self._elCol2 ~= nil then self._elCol2:invalidateLayout() end
+end
+
+-- -- Button -----------------------------------------------
+
+function MdGuideDialog:onClickClose()
+    g_gui:closeDialogByName(MdGuideDialog.GUI_NAME)
+end

--- a/src/gui/MdRfPdaGuest.lua
+++ b/src/gui/MdRfPdaGuest.lua
@@ -37,6 +37,10 @@ local NC_CHIP_IDS = {
 }
 -- BUILD 20:36: the Event settings plate (mdEsSummaryCard on the Events page) paints the same way.
 local ES_CHIP_IDS = { "mdEventSettingsBtn" }
+-- BUILD 17:21 (George CLOSED DESIGN 14:00): ONE Cancel chip on the open-contracts card, never one
+-- per row. Its own card id and its own wired flag: wireChipPaint stores the flag ON THE CARD, so
+-- reusing the New Contract card's flag would leave this card unwired.
+local CT_CHIP_IDS = { "mdCancelBtn" }
 -- Vanilla wideButton chip tints (guiProfiles: icon = colorMainHighlight, icon background =
 -- colorGreenDark), the same numbers CsRfPdaGuest.lua uses so both cards read as one family.
 local NC_CHIP_TEXT = { 0.22323, 0.40724, 0.00368 }
@@ -71,11 +75,20 @@ local _suppressSelectionCallback = false
 local _commoditySig = nil
 local _lastEventsSig = nil
 local _lastContractsSig = nil
+-- BUILD 17:21: the picked open deal, held by CONTRACT ID. FuturesMarket:getContractsForFarm walks
+-- pairs(self.contracts), so the returned order is not stable between the 2s repaints and a row index
+-- would silently drift onto another deal. _ctRowIds maps the row the player can see (1..5) to the id
+-- painted there on the last pass, and is rebuilt by every paint.
+local _selectedContractId = nil
+local _ctRowIds = {}
 -- BUILD 10:47: New Contract card state (Esc subset of MDMContractDialog: quantity + window +
 -- confirm for the crop picked in the top table) and its one feedback line.
 local _ncQty = 5000
 local _ncDays = 30
 local _ncFeedback = nil
+-- BUILD 17:21: the list paintContractsBand last painted, and the one Cancel feedback line.
+local _lastOpenContracts = {}
+local _ctFeedback = nil
 -- One-time ring seeds from MarketEngine history (fillTypeIndex → true). Never invent samples.
 local _historySeeded = {}
 -- Set by MarketScreen when deep-only load skipped Esc rail inject (prefer never stand-down mutate).
@@ -751,6 +764,20 @@ local function contractsSignature(list)
     return table.concat(parts, "|")
 end
 
+--- The open deal the player picked, re-resolved from the freshly painted list (never a stale row
+--- index). Returns the contract table, or nil when the pick is gone or is no longer cancellable.
+local function selectedContract(open)
+    if _selectedContractId == nil then
+        return nil
+    end
+    for _, c in ipairs(open or {}) do
+        if c.id == _selectedContractId then
+            return c
+        end
+    end
+    return nil
+end
+
 local function paintContractsBand(container)
     clearPricesBandGhosts(container)
     local mdm = getMdm()
@@ -771,7 +798,14 @@ local function paintContractsBand(container)
     if #open == 0 then
         open = list
     end
+    _lastOpenContracts = open
     _lastContractsSig = contractsSignature(open)
+    -- The row -> id map is rebuilt every paint, and a pick that has left the list (filled,
+    -- defaulted, cancelled elsewhere) is dropped here rather than acted on later.
+    _ctRowIds = {}
+    if selectedContract(open) == nil then
+        _selectedContractId = nil
+    end
 
     local n = #open
     local title = findDescendant(container, "mdContractsTitle")
@@ -793,6 +827,10 @@ local function paintContractsBand(container)
             setVis(findDescendant(container, "mdCtRow" .. i .. "Status"), false)
         end
         setText(findDescendant(container, "mdCtMore"), "")
+        for i = 1, MAX_CONTRACT_ROWS do
+            setVis(findDescendant(container, "mdCtRow" .. i), false)
+        end
+        _selectedContractId = nil
         return
     end
 
@@ -816,12 +854,20 @@ local function paintContractsBand(container)
             local locked = tonumber(c.lockedPrice) or 0
             setText(priceEl, string.format("%s / 1,000L", formatMoney(locked * 1000)))
             setText(statusEl, contractStatusLabel(c))
-            setTextColor(cropEl, unpack(COLOR_LIME))
+            -- BUILD 17:21: lime is now the PICK, not every row, so the highlight can be seen.
+            _ctRowIds[i] = c.id
+            if c.id ~= nil and c.id == _selectedContractId then
+                setTextColor(cropEl, unpack(COLOR_LIME))
+            else
+                setTextColor(cropEl, unpack(COLOR_FLAT))
+            end
+            setVis(findDescendant(container, "mdCtRow" .. i), true)
         else
             setVis(cropEl, false)
             setVis(qtyEl, false)
             setVis(priceEl, false)
             setVis(statusEl, false)
+            setVis(findDescendant(container, "mdCtRow" .. i), false)
         end
     end
     local moreEl = findDescendant(container, "mdCtMore")
@@ -851,6 +897,13 @@ local function isEventAdmin()
 end
 
 --- Same gate as MarketScreen:openContractDialog: BetterContracts owns the futures flow.
+--- True when this session runs the simulation itself (single player or a listen host), so a request
+--- has already been executed inline by the time the page repaints.
+local function isServerSession()
+    return g_currentMission ~= nil and type(g_currentMission.getIsServer) == "function"
+        and g_currentMission:getIsServer() == true
+end
+
 local function bcOwnsContracts()
     return BCIntegration ~= nil and type(BCIntegration.isEnabled) == "function" and BCIntegration.isEnabled() == true
 end
@@ -964,6 +1017,39 @@ end
 
 local function wireEsChipPaint(container)
     wireChipPaint(container, "mdEsSummaryCard", ES_CHIP_IDS, "_rfEsChipWired")
+end
+
+local function wireCtChipPaint(container)
+    wireChipPaint(container, "mdContractsOpenCard", CT_CHIP_IDS, "_rfCtChipWired")
+end
+
+--- The Cancel chip and the two lines around it. Painted after paintContractsBand on every full show
+--- and every light tick, so the chip follows the pick and the list. Gated (grey, disabled) until an
+--- ACTIVE deal is picked; hidden outright while BetterContracts owns the futures flow, the same
+--- silent stand-down MarketScreen:onContractRowClick makes.
+local function paintContractsCancelChip(container)
+    local btn = findDescendant(container, "mdCancelBtn")
+    local pickEl = findDescendant(container, "mdCtSelected")
+    local hintEl = findDescendant(container, "mdCancelHint")
+    if bcOwnsContracts() then
+        setVis(btn, false)
+        setText(pickEl, "")
+        setText(hintEl, tr("md_rf_pda_ct_bc", "BetterContracts is handling contracts. Cancel lives in its own screen."))
+        return
+    end
+    wireCtChipPaint(container)
+    local c = selectedContract(_lastOpenContracts)
+    local active = c ~= nil and (c.status or "active") == "active"
+    if c == nil then
+        setText(pickEl, tr("md_rf_pda_ct_pick", "Click a deal above to pick it."))
+    else
+        setText(pickEl, string.format(tr("md_rf_pda_ct_picked", "Picked: %s, %s L"),
+            tostring(c.fillTypeName or fillTypeTitle(c.fillTypeIndex) or "?"),
+            fmtInt(tonumber(c.quantity) or 0)))
+    end
+    setNcBtn(container, "mdCancelBtn", tr("md_rf_pda_ct_cancel", "Cancel deal"), active, false)
+    setText(hintEl, _ctFeedback or tr("md_rf_pda_ct_hint",
+        "Cancelling defaults the deal. Unfulfilled quantity is charged the default penalty."))
 end
 
 local function paintNewContractCard(container)
@@ -1195,8 +1281,17 @@ function MdRfPdaGuest.onNewContract(container)
     end
     local ok, why = ncSendRequest(crop, _ncQty, delivDays, isRealDays, ts)
     if ok then
-        _ncFeedback = string.format(tr("md_rf_pda_nc_sent", "Contract request sent: %s, %s L. It shows on the left when the server confirms."),
-            crop.title, fmtInt(_ncQty))
+        -- BUILD 19:15 (George CLOSED DESIGN 18:55 item 3): on a session that IS the server the create
+        -- has already run inline, and the open-deals list on the left is repainted from the live
+        -- contract table on this same pass, so there is nothing left to wait for. A dedicated client
+        -- keeps the waiting wording, because for it that is still true.
+        if isServerSession() then
+            _ncFeedback = string.format(tr("md_rf_pda_nc_opened", "Contract opened: %s, %s L."),
+                crop.title, fmtInt(_ncQty))
+        else
+            _ncFeedback = string.format(tr("md_rf_pda_nc_sent", "Contract request sent: %s, %s L. It shows on the left when the server confirms."),
+                crop.title, fmtInt(_ncQty))
+        end
     else
         _ncFeedback = why
     end
@@ -1233,6 +1328,7 @@ local function paintBottomByPage(container)
         paintEventSettingsBand(container)
     else
         paintContractsBand(container)
+        paintContractsCancelChip(container)
         paintNewContractCard(container)
     end
 end
@@ -1348,6 +1444,7 @@ function MdRfPdaGuest.onLightTick(container)
         paintEventSettingsBand(container)
     else
         paintContractsBand(container)
+        paintContractsCancelChip(container)
         -- Price and window can move between ticks; the summary line follows them.
         paintNewContractCard(container)
     end
@@ -1358,6 +1455,81 @@ function MdRfPdaGuest.onHide()
     _lastEventsSig = nil
     _lastContractsSig = nil
     _ncFeedback = nil
+    _selectedContractId = nil
+    _ctRowIds = {}
+    _lastOpenContracts = {}
+    _ctFeedback = nil
+end
+
+--- Row hit on the contracts card. The engine hands the clicked Button to the host callback and the
+--- host forwards it; the row number is read off the element id (mdCtRow3), then resolved through the
+--- row map the last paint built, so the pick is stored as a contract ID.
+---@param container table|nil
+---@param element table|nil
+function MdRfPdaGuest.onContractRow(container, element)
+    if bcOwnsContracts() then
+        return
+    end
+    local id = element ~= nil and element.id or nil
+    local row = id ~= nil and tonumber(string.match(tostring(id), "^mdCtRow(%d+)$")) or nil
+    if row == nil then
+        return
+    end
+    local contractId = _ctRowIds[row]
+    if contractId == nil then
+        return
+    end
+    _selectedContractId = contractId
+    _ctFeedback = nil
+    paintContractsBand(container)
+    paintContractsCancelChip(container)
+end
+
+--- The Cancel chip. Sends ACTION_PLAYER_FORFEIT for the picked deal, never ACTION_ADMIN_CANCEL:
+--- the zero-penalty admin path stays on the full Market admin dialog, which runs its own security
+--- check. On a host or single player sendToServer runs the action inline with no authorization
+--- pass at all, so every gate the chip needs is right here.
+---@param container table|nil
+function MdRfPdaGuest.onCancelContract(container)
+    if bcOwnsContracts() then
+        return
+    end
+    local c = selectedContract(_lastOpenContracts)
+    if c == nil then
+        _ctFeedback = tr("md_rf_pda_ct_pick", "Click a deal above to pick it.")
+        paintContractsCancelChip(container)
+        return
+    end
+    if (c.status or "active") ~= "active" then
+        _ctFeedback = tr("md_rf_pda_ct_not_open", "That deal is already settled.")
+        paintContractsCancelChip(container)
+        return
+    end
+    if c.id == nil or MDMContractRequestEvent == nil
+        or type(MDMContractRequestEvent.sendToServer) ~= "function" then
+        _ctFeedback = tr("md_rf_pda_ct_unavailable", "Contract service is not available right now.")
+        paintContractsCancelChip(container)
+        return
+    end
+    local ok = pcall(MDMContractRequestEvent.sendToServer,
+        MDMContractRequestEvent.ACTION_PLAYER_FORFEIT, { contractId = c.id })
+    if ok then
+        -- BUILD 19:15 (George CLOSED DESIGN 18:55 item 3): on a session that IS the server - single
+        -- player or a listen host - sendToServer runs the forfeit inline, and the repaint below
+        -- re-reads the contract list, so the deal is already gone by the time the player reads this.
+        -- Saying "when the server confirms" there is simply wrong. A dedicated client still waits.
+        local fillName = tostring(c.fillTypeName or fillTypeTitle(c.fillTypeIndex) or "?")
+        if isServerSession() then
+            _ctFeedback = string.format(tr("md_rf_pda_ct_cancelled", "Cancelled: %s. Leave-early fee charged."), fillName)
+        else
+            _ctFeedback = string.format(tr("md_rf_pda_ct_sent", "Cancel sent for %s. The list updates when the server confirms."), fillName)
+        end
+        _selectedContractId = nil
+    else
+        _ctFeedback = tr("md_rf_pda_ct_failed", "Cancel could not be sent.")
+    end
+    paintContractsBand(container)
+    paintContractsCancelChip(container)
 end
 
 function MdRfPdaGuest.getSelectedFillType()
@@ -1559,6 +1731,15 @@ local function mdPublishHandles()
     end
 end
 
+--- BUILD 19:15: the Esc Help footer asks whichever module is showing to open its own guide, so
+--- every companion ships and owns its own help instead of borrowing Soil's.
+---@param container table|nil
+function MdRfPdaGuest.onOpenHelp(container)
+    if MdGuideDialog ~= nil and type(MdGuideDialog.show) == "function" then
+        MdGuideDialog.show()
+    end
+end
+
 function MdRfPdaGuest.tryRegister()
     mdPublishHandles()
     if RfEscBootstrap ~= nil then
@@ -1569,6 +1750,12 @@ function MdRfPdaGuest.tryRegister()
                 profilesXml = MOD_DIR .. "xml/gui/rfEscProfiles.xml",
                 iconPath = "textures/ui/menuIcon.dds",
             })
+            -- BUILD 19:15 (George CLOSED DESIGN 18:55 item 5): load this mod's Field Guide at the
+            -- same moment the door itself loads. A GUI loaded from a mod directory later, once the
+            -- mod's own file system context has closed, fails to open.
+            if MdGuideDialog ~= nil and type(MdGuideDialog.register) == "function" then
+                pcall(MdGuideDialog.register, MOD_DIR)
+            end
             if not doorOk then
                 print("[MDM] MdRfPdaGuest: WARNING ensureDoor failed (will retry)")
             end
@@ -1607,6 +1794,7 @@ function MdRfPdaGuest.tryRegister()
             selectCommodityIndex = MdRfPdaGuest.selectCommodityIndex,
             onHide = MdRfPdaGuest.onHide,
             onMoverChanged = MdRfPdaGuest.onMoverChanged,
+            onOpenHelp = MdRfPdaGuest.onOpenHelp,
             -- BUILD 12:05: the open-full-market handler is gone with the Esc full-Market door.
         })
         if ok then
@@ -1643,4 +1831,8 @@ function MdRfPdaGuest.reset()
     _ncQty = 5000
     _ncDays = 30
     _ncFeedback = nil
+    _selectedContractId = nil
+    _ctRowIds = {}
+    _lastOpenContracts = {}
+    _ctFeedback = nil
 end

--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -233,6 +233,11 @@ function RfEscModules:registerModule(def)
         onOpenConsultant = def.onOpenConsultant,
         onOpenSchedule = def.onOpenSchedule,
         onOpenHelp = def.onOpenHelp,
+        -- BUILD 19:15: the shared Esc sheet's row click. registerModule rebuilds the descriptor field
+        -- by field, so a handler that is not named here is silently dropped and the control is dead.
+        -- That is what happened to onOpenFullMarket, onOpenConsultant, onPivotRemote, onLightTick,
+        -- onMoverChanged and onPageStep before it.
+        onSheetRow = def.onSheetRow,
         onPaintConsultant = def.onPaintConsultant,
         -- Same trap again, BUILD 15:46: the CS guest registers onPivotRemote on
         -- its module def (CsRfPdaGuest.lua) but it was missing here, so it was

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -701,6 +701,18 @@ function RfPdaMenuPage:initialize()
             self:onClickHelpCs()
         end
     }
+    -- BUILD 19:15 (George CLOSED DESIGN 18:55 item 5): ONE generic Help footer for the eight wave-2
+    -- modules. It never names a dialog: it asks the active guest to open its own Field Guide, so each
+    -- companion ships and owns its own help and a door hosted by any mod routes to the right one.
+    -- Soil keeps btnHelp and Crop Stress keeps btnHelpCs, which point at their own guides.
+    self.btnHelpFw = {
+        inputAction = InputAction.MENU_EXTRA_1,
+        showWhenPaused = true,
+        text = tr("rf_pda_btn_help", "Help"),
+        callback = function()
+            self:onClickHelpFw()
+        end
+    }
 
     -- Back only. Help is Soil-only and _syncHostGuestChrome adds it when the Soil
     -- module is the active one; seeding it here leaked Help onto every module's
@@ -1678,9 +1690,15 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     -- header and empty hint go dark on every refresh; NpcRfPdaGuest.onShow alone shows them, so
     -- Income / Dairy / Depot never inherit a live list. Nil-safe: thin doors have no such ids.
     -- BUILD 12:05: plus the two NPC detail cards (rfFwRosterDetailCard / rfFwFavorDetailCard).
+    -- BUILD 17:21: rfFwSheetBox joins the list. No host ever calls a guest onHide, so the shared
+    -- scrolling table has to go dark here or the module that showed it last keeps its rows on
+    -- screen under the next module's headers.
     for _, id in ipairs({ "rfFwRosterBox", "rfFwFavorBox", "rfFwFavEmpty",
                           "rfFwFavColGroup", "rfFwFavColWho", "rfFwFavColWhat", "rfFwFavColUrgency",
-                          "rfFwRosterDetailCard", "rfFwFavorDetailCard" }) do
+                          "rfFwRosterDetailCard", "rfFwFavorDetailCard", "rfFwSheetBox",
+                          -- BUILD 19:15: the selected-row band goes dark with its sheet, so a row
+                          -- read on Depot can never sit under another module's headers.
+                          "rfFwSheetBand" }) do
         local el = self:getDescendantById(id)
         if el ~= nil and type(el.setVisible) == "function" then
             el:setVisible(false)
@@ -1931,12 +1949,14 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     end
     -- BUILD 12:05 (George CLOSED DESIGN 09:45): Market footer is Back only; the Esc full-Market
     -- door is gone (Prices / Events / Contracts are the whole Market on this page).
+    -- BUILD 19:15: Back + Help for the eight wave-2 modules (Market, Worker Costs, Pro Staff and the
+    -- five framework pages). The Help entry is the generic one; the guest decides which guide opens.
     if isMd then
-        self.menuButtonInfo = { self.btnBack }
+        self.menuButtonInfo = { self.btnBack, self.btnHelpFw }
     elseif isWc then
-        -- BUILD 22:42 (George CLOSED DESIGN 21:26): Back only. Hire / Fire live on the page
+        -- BUILD 22:42 (George CLOSED DESIGN 21:26): Hire / Fire live on the page
         -- (wcBtnHireN / wcBtnFireN); Open Worker Manager is off the Esc footer.
-        self.menuButtonInfo = { self.btnBack }
+        self.menuButtonInfo = { self.btnBack, self.btnHelpFw }
     elseif isCs then
         -- BUILD Help restore 2026-08-12: Back + Help. Consultant chip stays off footer.
         self.menuButtonInfo = { self.btnBack, self.btnHelpCs }
@@ -1949,6 +1969,8 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         -- Both dialogs stay registered and still open from the PDA/joiner; only the
         -- duplicate bottom-bar buttons go, since the cards now carry that content.
         self.menuButtonInfo = { self.btnBack, self.btnHelp }
+    elseif isFw or activeId == "prostaff" then
+        self.menuButtonInfo = { self.btnBack, self.btnHelpFw }
     else
         self.menuButtonInfo = { self.btnBack }
     end
@@ -3382,10 +3404,42 @@ local function resolveListRowIndex(element)
         if el.rowDataIndex ~= nil then
             return el.rowDataIndex
         end
+        -- BUILD 19:15: rowDataIndex is stamped by THIS page's own populate, so it exists only while
+        -- the host is still the list's data source. A list a guest has taken over - the shared Esc
+        -- sheet - never carries it, and the click resolved to nil. The engine stamps
+        -- element.indexInSection on every populated cell and reads that same field back as the
+        -- clicked row, so it is the row number either way. Index 0 is a section header, never a row.
+        if type(el.indexInSection) == "number" and el.indexInSection > 0 and el.isEmptyCell ~= true then
+            return el.indexInSection
+        end
         el = el.parent
         guard = guard + 1
     end
     return nil
+end
+
+--- BUILD 19:15 (George CLOSED DESIGN 18:55 item 2): a click on the shared Esc table. The engine hands
+--- the clicked cell to the callback; resolveListRowIndex walks up to the row's own rowDataIndex, and
+--- the index goes to whichever guest is showing. A guest without onSheetRow is a quiet no-op, which is
+--- what Income wants: it has no band.
+function RfPdaMenuPage:onClickFwSheetRow(element)
+    local index = resolveListRowIndex(element)
+    if index == nil or index < 1 then return end
+    local host = self:_getHost()
+    local active = host and host.getActivePanel and host:getActivePanel()
+    if active ~= nil and type(active.onSheetRow) == "function" then
+        pcall(active.onSheetRow, index)
+    end
+end
+
+--- BUILD 19:15 (item 5): the generic Help footer. Every wave-2 guest publishes onOpenHelp and owns its
+--- own Field Guide dialog inside its own mod, so this never names one.
+function RfPdaMenuPage:onClickHelpFw()
+    local host = self:_getHost()
+    local active = host and host.getActivePanel and host:getActivePanel()
+    if active ~= nil and type(active.onOpenHelp) == "function" then
+        pcall(active.onOpenHelp, self.rfHostPlaceholder or self)
+    end
 end
 
 function RfPdaMenuPage:onClickFieldRow(element)
@@ -3569,5 +3623,18 @@ end
 
 function RfPdaMenuPage:onClickMdNcDays(element)
     _mdGuestCall(self, "onNcDays", self.rfHostPlaceholder or self, element)
+end
+
+--- BUILD 17:21 (George CLOSED DESIGN 14:00): pick an open deal on the Contracts page, then cancel
+--- it. mdCtRow1..5 are invisible hit targets laid over the five contract rows, so the engine hands
+--- the clicked Button to the callback and the guest reads the row number off its id; the pick is
+--- stored as a contract id, never a row index. Cancel is ONE chip (mdCancelBtn), and the guest owns
+--- every gate: BetterContracts stand-down, "is the pick still an open deal", and the request itself.
+function RfPdaMenuPage:onClickMdCtRow(element)
+    _mdGuestCall(self, "onContractRow", self.rfHostPlaceholder or self, element)
+end
+
+function RfPdaMenuPage:onClickMdCancel()
+    _mdGuestCall(self, "onCancelContract", self.rfHostPlaceholder or self)
 end
 

--- a/xml/gui/MdGuideDialog.xml
+++ b/xml/gui/MdGuideDialog.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<!--
+    Market Field Guide - Field Guide
+    5 tabs. Content is built in Lua and swapped per tab (one column pair).
+    Chrome copied from SoilGuideDialog so every Realistic Farming guide reads the same.
+    Controller: MdGuideDialog
+-->
+<GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
+  <GuiElement profile="newLayer"/>
+  <Bitmap profile="dialogFullscreenBg" id="dialogBg"/>
+
+  <GuiElement profile="mdGuide_bg" id="dialogElement">
+
+    <ThreePartBitmap profile="fs25_dialogBgMiddle"/>
+    <ThreePartBitmap profile="fs25_dialogBgTop"/>
+    <ThreePartBitmap profile="fs25_dialogBgBottom"/>
+
+    <GuiElement profile="fs25_dialogContentContainer">
+
+      <Text profile="fs25_dialogTitle" id="mdGuide_title" text="Market Field Guide" position="0px -28px"/>
+
+      <BoxLayout profile="mdGuide_tabRow" position="0px -66px">
+        <Button profile="mdGuide_tab" id="mdGuide_tab1" text="Overview" onClick="onClickTab1"/>
+        <Button profile="mdGuide_tab" id="mdGuide_tab2" text="How Prices Move" onClick="onClickTab2"/>
+        <Button profile="mdGuide_tab" id="mdGuide_tab3" text="Market Events" onClick="onClickTab3"/>
+        <Button profile="mdGuide_tab" id="mdGuide_tab4" text="Futures Contracts" onClick="onClickTab4"/>
+        <Button profile="mdGuide_tab" id="mdGuide_tab5" text="Settings and FAQ" onClick="onClickTab5"/>
+      </BoxLayout>
+
+      <Text profile="mdGuide_subtitle" id="mdGuide_subtitle" text="" position="0px -110px"/>
+
+      <GuiElement profile="mdGuide_colPanel" position="-253px -138px">
+        <Bitmap profile="mdGuide_colBg" position="0px 0px"/>
+        <BoxLayout profile="mdGuide_col" id="mdGuide_col1" position="0px -8px"/>
+      </GuiElement>
+
+      <GuiElement profile="mdGuide_colPanel" position="253px -138px">
+        <Bitmap profile="mdGuide_colBgAlt" position="0px 0px"/>
+        <BoxLayout profile="mdGuide_col" id="mdGuide_col2" position="0px -8px"/>
+      </GuiElement>
+
+    </GuiElement>
+
+    <BoxLayout profile="fs25_dialogButtonBox">
+      <Button profile="buttonOK" text="Close" onClick="onClickClose"/>
+    </BoxLayout>
+
+  </GuiElement>
+
+  <GUIProfiles>
+
+    <Profile name="mdGuide_bg" extends="fs25_dialogBg">
+      <size value="1120px 930px"/>
+    </Profile>
+
+    <Profile name="mdGuide_tabRow" extends="emptyPanel" with="anchorTopCenter">
+      <size value="960px 38px"/>
+      <flowDirection value="horizontal"/>
+      <elementSpacing value="10px"/>
+    </Profile>
+
+    <!-- The guide tabs and Close stay buttonOK: dialog chrome, not Esc overlay chips. -->
+    <Profile name="mdGuide_tab" extends="buttonOK">
+      <size value="174px 36px"/>
+      <textSize value="11px"/>
+      <textUpperCase value="true"/>
+    </Profile>
+
+    <Profile name="mdGuide_subtitle" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="960px 22px"/>
+      <textSize value="11px"/>
+      <textColor value="0.85 0.75 0.30 0.90"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="mdGuide_colPanel" extends="emptyPanel" with="anchorTopCenter">
+      <size value="510px 630px"/>
+    </Profile>
+    <Profile name="mdGuide_colBg" extends="baseReference" with="anchorTopCenter">
+      <size value="510px 630px"/>
+      <imageColor value="0.08 0.08 0.12 0.90"/>
+    </Profile>
+    <Profile name="mdGuide_colBgAlt" extends="baseReference" with="anchorTopCenter">
+      <size value="510px 630px"/>
+      <imageColor value="0.06 0.10 0.14 0.90"/>
+    </Profile>
+
+    <Profile name="mdGuide_col" extends="emptyPanel" with="anchorTopCenter">
+      <size value="494px 614px"/>
+      <flowDirection value="vertical"/>
+      <useFullVisibility value="false"/>
+      <alignmentX value="left"/>
+      <elementSpacing value="3px"/>
+    </Profile>
+
+    <Profile name="mdGuide_colHeader" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="472px 22px"/>
+      <textSize value="15px"/>
+      <textBold value="true"/>
+      <textUpperCase value="true"/>
+      <textColor value="1 0.8 0.2 1"/>
+      <textAlignment value="left"/>
+    </Profile>
+    <Profile name="mdGuide_colBody" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="472px 19px"/>
+      <textSize value="14px"/>
+      <textColor value="1 1 1 1"/>
+      <textAlignment value="left"/>
+    </Profile>
+    <Profile name="mdGuide_colSpacer" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="472px 10px"/>
+      <textSize value="8px"/>
+      <textColor value="0.0 0.0 0.0 0.0"/>
+    </Profile>
+
+  </GUIProfiles>
+</GUI>

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -622,54 +622,92 @@
                                  take it with an inline size rather than one profile per orientation. Declared
                                  before the cells so text paints over them. Per-cell hasFrame would have been 144
                                  frame rects for the same picture. -->
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleHead" position="10px -64px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow1" position="10px -92px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow2" position="10px -120px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow3" position="10px -148px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow4" position="10px -176px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow5" position="10px -204px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow6" position="10px -232px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow7" position="10px -260px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol1" position="300px -36px" size="1px 250px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol2" position="600px -36px" size="1px 250px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol3" position="840px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleHead" position="10px -64px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow1" position="10px -92px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow2" position="10px -120px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow3" position="10px -148px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow4" position="10px -176px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow5" position="10px -204px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow6" position="10px -232px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow7" position="10px -260px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol1" position="300px -36px" size="1px 250px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol2" position="600px -36px" size="1px 250px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol3" position="840px -36px" size="1px 250px" visible="false"/>
                             <Text profile="RF_FwColHeader" id="rfFwColA" position="10px -40px" size="280px 22px" text=""/>
                             <Text profile="RF_FwColHeader" id="rfFwColB" position="310px -40px" size="280px 22px" text=""/>
                             <Text profile="RF_FwColHeader" id="rfFwColC" position="610px -40px" size="220px 22px" text=""/>
                             <Text profile="RF_FwColHeader" id="rfFwColD" position="850px -40px" size="280px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="10px -68px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="310px -68px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="610px -68px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="850px -68px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="10px -96px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="310px -96px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="610px -96px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="850px -96px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="10px -124px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="310px -124px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="610px -124px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="850px -124px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="10px -152px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="310px -152px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="610px -152px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="850px -152px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="10px -180px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="310px -180px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="610px -180px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="850px -180px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="10px -208px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="310px -208px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="610px -208px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="850px -208px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="10px -236px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="310px -236px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="610px -236px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="850px -236px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="10px -264px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="310px -264px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="10px -68px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="310px -68px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="610px -68px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="850px -68px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="10px -96px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="310px -96px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="610px -96px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="850px -96px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="10px -124px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="310px -124px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="610px -124px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="850px -124px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="10px -152px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="310px -152px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="610px -152px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="850px -152px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="10px -180px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="310px -180px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="610px -180px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="850px -180px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="10px -208px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="310px -208px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="610px -208px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="850px -208px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="10px -236px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="310px -236px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="610px -236px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="850px -236px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="10px -264px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="310px -264px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -548px" size="1120px 20px" text=""/>
+                            <!-- BUILD 17:21 (George CLOSED DESIGN 14:00): the shared table scrolls. ONE SmoothList
+                                 under this GuiElement host (rfFwTableBlock is a GuiElement, never a Map Bitmap: the
+                                 hang fence), the NPC Favor nest, the sheet's own 28px pitch and the same four column
+                                 X as rfFwColA..D, so the headers above it still line up. Painted by whichever Table
+                                 guest is showing (Income, Depot); hidden by default and hidden again on every host
+                                 refresh, so no module inherits another's rows. The 32 rfFwRow* cells above stay
+                                 declared and unused: Dairy, NPC Favor and Pro Staff each hide them by id, and a door
+                                 must never lose an id a shipped guest still names. -->
+                            <!-- BUILD 19:15 (George CLOSED DESIGN 18:55): the sheet fills the bay like the Soil field
+                                 list - 480 tall, 48px rows, 18px cells - so ten full rows read at a glance instead of
+                                 eight cramped ones. Bottom sits at -540; rfFwMore follows at -548 and rfFwHintTable at
+                                 -576, and nothing in this block goes below -740, which is what keeps the Pro Staff
+                                 Buy / Run strip at -748 clear. Cell X and widths are untouched so rfFwColA..D still
+                                 head their own columns. The ListItem carries the row click; the host resolves the row
+                                 index and hands it to whichever guest is showing. -->
+                            <GuiElement profile="RF_FwListBox" id="rfFwSheetBox" position="10px -60px" size="1120px 480px" visible="false">
+                                <SmoothList id="rfFwSheetList" profile="RF_FwSheetList" size="1112px 480px" handleFocus="false"
+                                            startClipperElementName="rfFwSheetStart" endClipperElementName="rfFwSheetEnd">
+                                    <ListItem profile="RF_FwSheetItem" height="48px" onClick="onClickFwSheetRow">
+                                        <Bitmap profile="RF_RowBg" name="alternating"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetA" position="0px 0px" size="280px 48px"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetB" position="300px 0px" size="280px 48px"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetC" position="600px 0px" size="220px 48px"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetD" position="840px 0px" size="272px 48px"/>
+                                    </ListItem>
+                                </SmoothList>
+                                <Bitmap profile="RF_SheetStartClipper" name="rfFwSheetStart"/>
+                                <Bitmap profile="RF_SheetStopClipper" name="rfFwSheetEnd"/>
+                                <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                    <Slider profile="fs25_listSlider" dataElementId="rfFwSheetList" hideParentWhenEmpty="true"/>
+                                </ThreePartBitmap>
+                            </GuiElement>
+                            <!-- BUILD 19:15: the readout for the row the player clicked. Text only, no chip. Hidden by
+                                 default and hidden again on every host refresh beside rfFwSheetBox, so it can never
+                                 carry one module's row onto another module's page. The Depot guest fills it; Income
+                                 has no band and its onSheetRow is a no-op. -->
+                            <Text profile="RF_SheetBand" id="rfFwSheetBand" position="10px -664px" size="1120px 72px"
+                                  textMaxNumLines="3" textVerticalAlignment="top" visible="false" text=""/>
                             <!-- BUILD 00:06 (George CLOSED DESIGN 23:12): the rfFwPagePrev / rfFwPageNext row pager is gone;
                                  the NPC Favor tables scroll (rfFwRosterList / rfFwFavorList below). The host keyEvent page
                                  belt (. / , keys) still serves a guest that registers onPageStep (Dairy cards). -->
@@ -689,7 +727,7 @@
                                     visible="false" text="" onClick="onClickPsFlush"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"
+                            <Text profile="RF_HintText" id="rfFwHintTable" position="10px -576px" size="1120px 80px"
                                   textMaxNumLines="3" textVerticalAlignment="top" text=""/>
                             <!-- BUILD 00:06 (George CLOSED DESIGN 23:12, Ash 00:06): NPC Favor scrollable tables. Two SmoothLists
                                  under this GuiElement host (rfFwTableBlock is a GuiElement, never a Map Bitmap: the hang fence),
@@ -1504,6 +1542,20 @@
                                 <Text profile="RF_HintText" id="mdCtMore" textSize="13px" position="10px -186px" size="530px 20px" text=""/>
                                 <Text profile="RF_HintText" id="mdContractsEmpty" textSize="13px" position="10px -62px" size="530px 44px"
                                       textMaxNumLines="2" visible="false" text=""/>
+                                <!-- BUILD 17:21 (George CLOSED DESIGN 14:00): pick an open deal, then Cancel it. The five
+                                     hit targets sit ON the row bands and paint nothing (RF_CtRowHit); they are declared
+                                     after the row Texts so the transparent button draws over the text without hiding it.
+                                     ONE Cancel chip, never one per row. handleFocus="false" and the profile's
+                                     isTriggerableByGlobalAction="false" are the overlay-chip law: SPACE never confirms it. -->
+                                <Button profile="RF_CtRowHit" id="mdCtRow1" position="10px -62px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow2" position="10px -86px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow3" position="10px -110px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow4" position="10px -134px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow5" position="10px -158px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Text profile="RF_HintText" id="mdCtSelected" textSize="13px" position="10px -212px" size="530px 20px" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="mdCancelBtn" position="10px -238px" size="170px 32px" handleFocus="false" visible="false" text="" onClick="onClickMdCancel"/>
+                                <Text profile="RF_HintText" id="mdCancelHint" textSize="13px" position="190px -234px" size="350px 40px"
+                                      textMaxNumLines="2" text=""/>
                             </GuiElement>
                             <GuiElement profile="RF_EscCardFrame" id="mdNewContractCard" position="580px 0px" size="550px 344px">
                                 <Text profile="RF_SectionTitle" id="mdNewContractTitle" position="10px -6px" size="530px 22px" text=""/>

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -727,6 +727,49 @@
         <textVerticalAlignment value="middle"/>
     </Profile>
 
+    <!-- BUILD 17:21: the shared Esc table list. 28px rows are the sheet's own pitch, so the four
+         column headers above the box still line up; the clippers are 12px because the engine's own
+         are 39px, sized for the 420px roster box. -->
+    <Profile name="RF_FwSheetList" extends="RF_SmoothList">
+        <size value="1112px 480px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <!-- BUILD 19:15: the Soil field-list family - 48px rows and 18px cells - so the shared table reads
+         at the same weight as the Soil list instead of a denser one. -->
+    <Profile name="RF_FwSheetItem" extends="RF_ListRow">
+        <height value="48px"/>
+    </Profile>
+    <Profile name="RF_FwSheetCell" extends="RF_FwListCell">
+        <textSize value="18px"/>
+        <textBold value="false"/>
+        <textMaxNumLines value="1"/>
+        <textVerticalAlignment value="middle"/>
+    </Profile>
+    <!-- 24px is proportional for a 480px box the way the engine's own 39px is for the 420px roster. -->
+    <Profile name="RF_SheetStartClipper" extends="fs25_secondaryMenuStartClipper">
+        <height value="24px"/>
+    </Profile>
+    <Profile name="RF_SheetStopClipper" extends="fs25_secondaryMenuStopClipper">
+        <height value="24px"/>
+    </Profile>
+    <!-- BUILD 19:15: the selected-row readout under the sheet. Three lines of hint text, top aligned. -->
+    <Profile name="RF_SheetBand" extends="RF_HintText">
+        <textSize value="18px"/>
+        <textMaxNumLines value="3"/>
+        <textVerticalAlignment value="top"/>
+    </Profile>
+
+    <!-- BUILD 17:21 (George CLOSED DESIGN 14:00): an invisible per-row hit target for the Esc Market
+         contracts rows. It extends the pivot chip so the overlay-chip law's guards come with it
+         (hideKeyboardGlyph, isTriggerableByGlobalAction false, so SPACE can never activate a row);
+         nothing paints because fs25_wideButton's own background is emptyPanel-transparent, the icon
+         is sized away and the label is empty. -->
+    <Profile name="RF_CtRowHit" extends="RF_CsPivotBtn">
+        <size value="530px 24px"/>
+        <iconSize value="0px 0px"/>
+        <textSize value="1px"/>
+    </Profile>
+
     <!-- BUILD 11:40 (George CLOSED DESIGN 11:25): the in-card herd / milk breed lists on the Dairy cards.
          20px rows = four visible in the 80px box (today's density); the slider shows only when rows overflow. -->
     <Profile name="RF_DairyBreedList" extends="RF_SmoothList">


### PR DESCRIPTION
## Summary
- Leftover eight-row hairlines on the shared Realistic Farming page stay hidden.
- Market Cancel chip stays.

## Test plan
- [ ] Full restart. Esc Market: no ghost eight-row table. Cancel chip still there.
